### PR TITLE
feat(profiles): implement encryption profiles, raw mode & security hardening

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
 
     // --- Coroutines ---
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
-    implementation(libs.androidx.foundation)
+    implementation("androidx.compose.foundation:foundation")
 
     // --- Testing ---
     testImplementation("junit:junit:4.13.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2025.12.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         targetSdk = 36
         versionCode = 11
         //Todo: Change on each revision
-        versionName = "0.5.0-dev01"
+        versionName = "0.5.0-dev02"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -84,6 +84,7 @@ dependencies {
 
     // --- Coroutines ---
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
+    implementation(libs.androidx.foundation)
 
     // --- Testing ---
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/dev/animeshvarma/sigil/MainActivity.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/MainActivity.kt
@@ -8,7 +8,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,6 +20,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ViewModelProvider
 import dev.animeshvarma.sigil.data.LockManager
+import dev.animeshvarma.sigil.model.LockMode
 import dev.animeshvarma.sigil.ui.OnboardingOrchestrator
 import dev.animeshvarma.sigil.ui.SigilApp
 import dev.animeshvarma.sigil.ui.screens.LockScreen
@@ -32,7 +33,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var viewModel: SigilViewModel
     private lateinit var prefs: SigilPreferences
 
-    private val isLockedState = mutableStateOf(false)
+    private val isContentHidden = mutableStateOf(true)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,33 +43,34 @@ class MainActivity : AppCompatActivity() {
         prefs = SigilPreferences(this)
         lockManager = LockManager(this)
 
-        // 1. SHIELD PROTOCOL: Immediate Screen Protection
         updateSecureFlag()
 
-        // 2. GATEKEEPER: Check Lock Status on Cold Start
-        if (lockManager.isAppLocked()) {
-            isLockedState.value = true
-        }
+        isContentHidden.value = lockManager.isAppLocked()
 
-        // 3. AMNESIA PROTOCOL: Lifecycle Enforcer
+        // --- LIFECYCLE SECURITY OBSERVER ---
         lifecycle.addObserver(LifecycleEventObserver { _, event ->
             when (event) {
+                Lifecycle.Event.ON_PAUSE -> {
+                    if (prefs.lockMode != LockMode.NONE) {
+                        isContentHidden.value = true
+                    }
+                }
                 Lifecycle.Event.ON_STOP -> {
                     lockManager.recordBackgroundEvent()
-                    updateSecureFlag()
+
+                    if (!prefs.isGracePeriodEnabled && prefs.lockMode != LockMode.NONE) {
+                        viewModel.clearSensitiveData()
+                    }
                 }
                 Lifecycle.Event.ON_START -> {
                     updateSecureFlag()
 
+
                     if (lockManager.isAppLocked()) {
-                        isLockedState.value = true
+                        isContentHidden.value = true
                         viewModel.clearSensitiveData()
-                    }
-                }
-                Lifecycle.Event.ON_RESUME -> {
-                    if (!isLockedState.value && lockManager.isAppLocked()) {
-                        isLockedState.value = true
-                        viewModel.clearSensitiveData()
+                    } else {
+                        isContentHidden.value = false
                     }
                 }
                 else -> {}
@@ -78,11 +80,9 @@ class MainActivity : AppCompatActivity() {
         // Onboarding Check
         val showOnboarding = mutableStateOf(!prefs.hasCompletedOnboarding())
 
-        // Process any incoming text sharing
         checkAndProcessIntent(intent, viewModel)
 
         setContent {
-            // Theme Injection
             val systemDark = isSystemInDarkTheme()
             val useDarkTheme = if (prefs.isDynamicColorsEnabled) systemDark else prefs.isDarkModeEnabled
 
@@ -94,26 +94,24 @@ class MainActivity : AppCompatActivity() {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     Box(modifier = Modifier.padding(innerPadding)) {
 
-                        // LAYER 1: MAIN APPLICATION
-                        SigilApp(viewModel = viewModel)
-
-                        // LAYER 2: LOCK SCREEN OVERLAY
-                        if (isLockedState.value) {
+                        // Show LockScreen if hidden
+                        if (isContentHidden.value && prefs.lockMode != LockMode.NONE) {
                             LockScreen(
                                 viewModel = viewModel,
                                 onUnlock = {
-                                    isLockedState.value = false
+                                    isContentHidden.value = false
                                     viewModel.consumePendingIntent()
                                 }
                             )
-                        }
-
-                        // LAYER 3: ONBOARDING
-                        if (!isLockedState.value) {
+                        } else {
                             AnimatedVisibility(
-                                visible = showOnboarding.value,
-                                exit = fadeOut(animationSpec = tween(500))
+                                visible = true,
+                                enter = fadeIn(tween(300))
                             ) {
+                                SigilApp(viewModel = viewModel)
+                            }
+
+                            if (showOnboarding.value) {
                                 OnboardingOrchestrator(
                                     viewModel = viewModel,
                                     onComplete = {
@@ -135,14 +133,21 @@ class MainActivity : AppCompatActivity() {
         checkAndProcessIntent(intent, viewModel)
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        if (prefs.lockMode != LockMode.NONE) {
+            viewModel.clearSensitiveData()
+        }
+        super.onSaveInstanceState(outState)
+    }
+
     private fun checkAndProcessIntent(intent: Intent?, viewModel: SigilViewModel) {
         if (intent?.action == Intent.ACTION_SEND && intent.type == "text/plain") {
             intent.getStringExtra(Intent.EXTRA_TEXT)?.let { sharedText ->
                 intent.removeExtra(Intent.EXTRA_TEXT)
 
-                if (lockManager.isAppLocked() || isLockedState.value) {
+                if (isContentHidden.value || prefs.lockMode != LockMode.NONE) {
                     viewModel.cachePendingIntent(sharedText)
-                    isLockedState.value = true
+                    isContentHidden.value = true
                 } else {
                     viewModel.handleIncomingSharedText(sharedText)
                 }

--- a/app/src/main/java/dev/animeshvarma/sigil/MainActivity.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/MainActivity.kt
@@ -35,6 +35,16 @@ class MainActivity : AppCompatActivity() {
 
     private val isContentHidden = mutableStateOf(true)
 
+    /**
+     * Initializes the activity UI, security, lifecycle observers, onboarding state, intent handling, and Compose content.
+     *
+     * Sets up edge-to-edge rendering, view model, preferences, and lock manager; applies screen security flags; initializes
+     * the content-hidden state from the lock manager; registers a lifecycle observer to hide content on pause, record
+     * background events and clear sensitive data on stop (when configured), and re-evaluate secure flag and content visibility
+     * on start. Checks and processes incoming share intents, determines whether onboarding should be shown, and composes
+     * the app UI: shows a lock screen when content is hidden and locking is enabled, otherwise displays the main app with
+     * theming and onboarding orchestration.
+     */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -127,12 +137,22 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    /**
+     * Handle a newly delivered intent, update the activity's current intent, and process any shared content it carries.
+     *
+     * @param intent The new Intent delivered to the activity.
+     */
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         checkAndProcessIntent(intent, viewModel)
     }
 
+    /**
+     * Ensures sensitive in-memory data is cleared when saving instance state if a lock mode is enabled.
+     *
+     * @param outState Bundle in which to place saved state.
+     */
     override fun onSaveInstanceState(outState: Bundle) {
         if (prefs.lockMode != LockMode.NONE) {
             viewModel.clearSensitiveData()
@@ -140,6 +160,14 @@ class MainActivity : AppCompatActivity() {
         super.onSaveInstanceState(outState)
     }
 
+    /**
+     * Processes an incoming ACTION_SEND "text/plain" intent by either handling its shared text immediately or caching it for later.
+     *
+     * If the intent contains EXTRA_TEXT, the extra is removed from the intent. If the app content is currently hidden or a lock mode is enabled, the shared text is cached via the view model and the content is marked hidden; otherwise the shared text is delivered to the view model for immediate handling. Non-matching or null intents are ignored.
+     *
+     * @param intent The incoming intent that may contain shared text (may be null).
+     * @param viewModel The view model used to handle or cache the shared text.
+     */
     private fun checkAndProcessIntent(intent: Intent?, viewModel: SigilViewModel) {
         if (intent?.action == Intent.ACTION_SEND && intent.type == "text/plain") {
             intent.getStringExtra(Intent.EXTRA_TEXT)?.let { sharedText ->

--- a/app/src/main/java/dev/animeshvarma/sigil/MainActivity.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/MainActivity.kt
@@ -6,9 +6,8 @@ import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -75,7 +74,6 @@ class MainActivity : AppCompatActivity() {
                 Lifecycle.Event.ON_START -> {
                     updateSecureFlag()
 
-
                     if (lockManager.isAppLocked()) {
                         isContentHidden.value = true
                         viewModel.clearSensitiveData()
@@ -104,31 +102,35 @@ class MainActivity : AppCompatActivity() {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     Box(modifier = Modifier.padding(innerPadding)) {
 
-                        // Show LockScreen if hidden
-                        if (isContentHidden.value && prefs.lockMode != LockMode.NONE) {
-                            LockScreen(
-                                viewModel = viewModel,
-                                onUnlock = {
-                                    isContentHidden.value = false
-                                    viewModel.consumePendingIntent()
-                                }
-                            )
-                        } else {
-                            AnimatedVisibility(
-                                visible = true,
-                                enter = fadeIn(tween(300))
-                            ) {
-                                SigilApp(viewModel = viewModel)
-                            }
+                        val isLocked = isContentHidden.value && prefs.lockMode != LockMode.NONE
 
-                            if (showOnboarding.value) {
-                                OnboardingOrchestrator(
+                        Crossfade(
+                            targetState = isLocked,
+                            animationSpec = tween(400),
+                            label = "LockScreenTransition"
+                        ) { locked ->
+                            if (locked) {
+                                LockScreen(
                                     viewModel = viewModel,
-                                    onComplete = {
-                                        prefs.setOnboardingCompleted(true)
-                                        showOnboarding.value = false
+                                    onUnlock = {
+                                        isContentHidden.value = false
+                                        viewModel.consumePendingIntent()
                                     }
                                 )
+                            } else {
+                                Box(modifier = Modifier.fillMaxSize()) {
+                                    SigilApp(viewModel = viewModel)
+
+                                    if (showOnboarding.value) {
+                                        OnboardingOrchestrator(
+                                            viewModel = viewModel,
+                                            onComplete = {
+                                                prefs.setOnboardingCompleted(true)
+                                                showOnboarding.value = false
+                                            }
+                                        )
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
@@ -177,6 +177,67 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
+     * Updates an existing custom profile by ID with new configuration.
+     *
+     * @param id The ID of the profile to update.
+     * @param name The new display name.
+     * @param description The new description.
+     * @param layers The new list of algorithms.
+     * @param kdfOverride The new KDF configuration override (or null).
+     * @param compress Whether compression is enabled.
+     * @param isRaw Whether raw mode is enabled.
+     * @param onSuccess Callback invoked after successful update.
+     */
+    fun updateExistingProfile(
+        id: String,
+        name: String,
+        description: String,
+        layers: List<CryptoEngine.Algorithm>,
+        kdfOverride: CryptoEngine.KdfConfig?,
+        compress: Boolean,
+        isRaw: Boolean,
+        onSuccess: () -> Unit
+    ) {
+        if (name.isBlank()) {
+            addLog("Error: Profile name required.")
+            return
+        }
+        if (layers.isEmpty()) {
+            addLog("Error: Cannot save empty chain.")
+            return
+        }
+
+        val currentCustom = prefs.getCustomProfiles().toMutableList()
+        val index = currentCustom.indexOfFirst { it.id == id }
+
+        if (index != -1) {
+            // Check if name is taken by ANOTHER profile
+            val collision = currentCustom.any { it.id != id && it.name.equals(name, ignoreCase = true) }
+            if (collision) {
+                addLog("Error: Profile name '$name' is already taken.")
+                return
+            }
+
+            val updated = currentCustom[index].copy(
+                name = name,
+                description = description,
+                layers = layers,
+                kdfConfig = kdfOverride,
+                isCompressionEnabled = compress,
+                isRaw = isRaw
+            )
+            currentCustom[index] = updated
+            prefs.saveCustomProfiles(currentCustom)
+            loadProfiles()
+            selectProfile(updated)
+            onSuccess()
+            addLog("Profile Updated: $name")
+        } else {
+            addLog("Error: Profile not found for update.")
+        }
+    }
+
+    /**
      * Replaces an existing custom encryption profile with the provided profile (matched by name, case-insensitive) and applies it as active.
      *
      * If a custom profile with the same name exists, this updates the stored custom profiles, reloads available profiles, selects the updated profile, and records a log entry.
@@ -214,18 +275,6 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
             }
             addLog("Profile Deleted.")
         }
-    }
-
-    /**
-     * Resets custom encryption profiles to defaults.
-     *
-     * Clears all stored custom profiles, reloads the available profiles list, selects the built-in default profile, and records a log entry about the reset.
-     */
-    fun resetProfiles() {
-        prefs.saveCustomProfiles(emptyList())
-        loadProfiles()
-        selectProfile(ProfileRegistry.defaultProfile)
-        addLog("All custom profiles cleared. Reset to defaults.")
     }
 
     /**
@@ -312,7 +361,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
      * Populates the custom layer list, applies the profile's compression setting, marks the profile as
      * being edited, and records the action in the logs.
      *
-     * @param profile The EncryptionProfile to load into the custom editor. 
+     * @param profile The EncryptionProfile to load into the custom editor.
      */
     fun loadProfileToCustomMode(profile: EncryptionProfile) {
         _uiState.update {
@@ -464,7 +513,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
                         compress = state.isCompressionEnabled
                     }
 
-                    if (chain.isEmpty()) throw Exception("No encryption layers selected.")
+                    if (chain.isEmpty()) throw IllegalStateException("No encryption layers selected.")
 
                     result = CryptoEngine.encrypt(
                         data = input.toByteArray(StandardCharsets.UTF_8),
@@ -578,7 +627,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
                     errorReport.append(" • Credentials: Is the password/key correct?\n")
                     errorReport.append(" • Integrity: The data may be corrupted or truncated.\n")
                     errorReport.append(" • Security Parameters: Check KDF iterations and memory limits.\n")
-                    errorReport.append(" • Profile Context: Ensure you aren't using a the correct profile.\n")
+                    errorReport.append(" • Profile Context: Ensure you are using the correct profile.\n")
                 }
 
                 val finalMessage = errorReport.toString()
@@ -855,47 +904,17 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
-     * Resets application preferences and ViewModel internal state, and optionally restarts the app.
+     * Toggle use of dynamic system-derived colors for the app theme.
      *
-     * This clears demo mode, resets all stored preferences to their defaults (committing them synchronously when a restart is requested), and appends a log entry. If `shouldRestart` is true, the application is restarted and the current process is terminated after preferences are committed.
-     *
-     * @param shouldRestart If true, commit preferences synchronously and restart the application process; otherwise perform a non-restarting reset.
+     * @param enabled `true` to enable dynamic colors (use system-derived palette), `false` to disable them (use app-defined colors).
      */
-    fun resetAppPreferences(shouldRestart: Boolean) {
-        // 1. Reset Internal ViewModel State
-        setDemoMode(false)
-
-        // 2. Reset Preferences
-        prefs.resetAllSettings(synchronous = shouldRestart)
-
-        addLog("Preferences reset to defaults.")
-
-        // 3. Restart if requested
-        if (shouldRestart) {
-            val context = getApplication<Application>()
-            val packageManager = context.packageManager
-            val intent = packageManager.getLaunchIntentForPackage(context.packageName)
-            val componentName = intent?.component
-            val mainIntent = Intent.makeRestartActivityTask(componentName)
-            context.startActivity(mainIntent)
-
-            // Now safe to kill process because preferences are committed
-            exitProcess(0)
-        }
-    }
-
+    fun setDynamicColors(enabled: Boolean) { prefs.isDynamicColorsEnabled = enabled }
     /**
- * Toggle use of dynamic system-derived colors for the app theme.
- *
- * @param enabled `true` to enable dynamic colors (use system-derived palette), `false` to disable them (use app-defined colors).
- */
-fun setDynamicColors(enabled: Boolean) { prefs.isDynamicColorsEnabled = enabled }
-    /**
- * Sets whether the app should use dark theme.
- *
- * @param enabled `true` to enable dark mode, `false` to disable it.
- */
-fun setDarkMode(enabled: Boolean) { prefs.isDarkModeEnabled = enabled }
+     * Sets whether the app should use dark theme.
+     *
+     * @param enabled `true` to enable dark mode, `false` to disable it.
+     */
+    fun setDarkMode(enabled: Boolean) { prefs.isDarkModeEnabled = enabled }
     /**
      * Updates the application's selected theme color and persists it in preferences.
      *

--- a/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
@@ -471,15 +471,17 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
             } catch (_: Exception) {
                 val errorReport = StringBuilder()
                 if (state.selectedMode == SigilMode.AUTO && state.activeProfile.isRaw) {
-                    errorReport.append("RAW DECRYPTION FAILED\n\n")
-                    errorReport.append("Raw mode has NO integrity checks. The password or profile is incorrect, or the data is garbage.")
+                    errorReport.append("Raw Decryption Failed\n")
+                    errorReport.append("--------------------------\n")
+                    errorReport.append("Integrity validation is disabled in Raw mode. Please manually ensure the password, profile, and data are correct.")
                 } else {
-                    errorReport.append("DECRYPTION FAILED\n\n")
-                    errorReport.append("POSSIBLE CAUSES:\n")
-                    errorReport.append("1. Wrong password.\n")
-                    errorReport.append("2. Corrupted data.\n")
-                    errorReport.append("3. Security mismatch (Check KDF iterations/memory).\n")
-                    errorReport.append("4. Profile mismatch (Are you trying to decrypt Raw data with a Container profile?).\n")
+                    errorReport.append("Decryption Failed\n")
+                    errorReport.append("--------------------------\n")
+                    errorReport.append("The system could not decrypt the data. Please verify the following:\n")
+                    errorReport.append(" • Credentials: Is the password/key correct?\n")
+                    errorReport.append(" • Integrity: The data may be corrupted or truncated.\n")
+                    errorReport.append(" • Security Parameters: Check KDF iterations and memory limits.\n")
+                    errorReport.append(" • Profile Context: Ensure you aren't using a the correct profile.\n")
                 }
 
                 val finalMessage = errorReport.toString()

--- a/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
@@ -69,12 +69,20 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
     private fun loadProfiles() {
         val customProfiles = prefs.getCustomProfiles()
         val allProfiles = ProfileRegistry.builtInProfiles + customProfiles
+
+        val savedId = prefs.activeProfileId
+        val active = allProfiles.find { it.id == savedId } ?: ProfileRegistry.defaultProfile
+
         _uiState.update {
-            it.copy(availableProfiles = allProfiles)
+            it.copy(
+                availableProfiles = allProfiles,
+                activeProfile = active
+            )
         }
     }
 
     fun selectProfile(profile: EncryptionProfile) {
+        prefs.activeProfileId = profile.id
         _uiState.update { it.copy(activeProfile = profile) }
         addLog("Profile Switched: ${profile.name}")
     }

--- a/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
@@ -57,10 +57,21 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
 
     private var pendingSharedText: String? = null
 
+    private var currentViewModelToast: Toast? = null
+
     init {
         viewModelScope.launch(Dispatchers.IO) {
             refreshVault()
             loadProfiles()
+        }
+    }
+
+    private fun showBackgroundToast(message: String) {
+        viewModelScope.launch(Dispatchers.Main) {
+            currentViewModelToast?.cancel()
+            val toast = Toast.makeText(getApplication(), message, Toast.LENGTH_SHORT)
+            currentViewModelToast = toast
+            toast.show()
         }
     }
 
@@ -93,6 +104,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         layers: List<CryptoEngine.Algorithm>,
         kdfOverride: CryptoEngine.KdfConfig?,
         compress: Boolean,
+        isRaw: Boolean,
         onSuccess: () -> Unit,
         onDuplicateName: (EncryptionProfile) -> Unit
     ) {
@@ -121,7 +133,8 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
             layers = layers,
             kdfConfig = kdfOverride,
             isCompressionEnabled = compress,
-            isBuiltIn = false
+            isBuiltIn = false,
+            isRaw = isRaw
         )
 
         currentCustom.add(newProfile)
@@ -162,18 +175,6 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         loadProfiles()
         selectProfile(ProfileRegistry.defaultProfile)
         addLog("All custom profiles cleared. Reset to defaults.")
-    }
-
-    fun loadProfileToCustomMode(profile: EncryptionProfile) {
-        _uiState.update {
-            it.copy(
-                customLayers = profile.layers.map { algo -> LayerEntry(algorithm = algo) },
-                isCompressionEnabled = profile.isCompressionEnabled,
-                editingProfileId = profile.id,
-                selectedMode = SigilMode.CUSTOM
-            )
-        }
-        addLog("Editing Profile: '${profile.name}'")
     }
 
     fun getProfileById(id: String): EncryptionProfile? {
@@ -235,6 +236,18 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
                 editingProfileId = if (mode == SigilMode.CUSTOM) null else it.editingProfileId
             )
         }
+    }
+
+    fun loadProfileToCustomMode(profile: EncryptionProfile) {
+        _uiState.update {
+            it.copy(
+                customLayers = profile.layers.map { algo -> LayerEntry(algorithm = algo) },
+                isCompressionEnabled = profile.isCompressionEnabled,
+                editingProfileId = profile.id,
+                selectedMode = SigilMode.CUSTOM
+            )
+        }
+        addLog("Editing Profile: '${profile.name}'")
     }
 
     fun onScreenSelected(screen: AppScreen) {
@@ -312,8 +325,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
     // --- CRYPTO OPERATIONS ---
     fun onEncrypt() {
         val state = _uiState.value
-        val pwdString =
-            if (state.selectedMode == SigilMode.AUTO) state.autoPassword else state.customPassword
+        val pwdString = if (state.selectedMode == SigilMode.AUTO) state.autoPassword else state.customPassword
         val input = if (state.selectedMode == SigilMode.AUTO) state.autoInput else state.customInput
 
         if (pwdString.isEmpty()) {
@@ -324,7 +336,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         // TRIGGER LOADING
         _uiState.update { it.copy(isLoading = true) }
 
-        // AGGRESSIVE WIPE: Clear password from UI immediately so it doesn't linger in View State
+        // Wipe password from UI state
         _uiState.update {
             if (it.selectedMode == SigilMode.AUTO) it.copy(autoPassword = "")
             else it.copy(customPassword = "")
@@ -335,36 +347,52 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch(Dispatchers.IO) {
             val pwdChars = pwdString.toCharArray()
             try {
-                val chain: List<CryptoEngine.Algorithm>
-                val compress: Boolean
+                val result: String
                 val kdfConfig = getActiveKdfConfig()
 
-                if (state.selectedMode == SigilMode.AUTO) {
+                // CHECK FOR RAW PROFILE IN AUTO MODE
+                if (state.selectedMode == SigilMode.AUTO && state.activeProfile.isRaw) {
                     val profile = state.activeProfile
-                    chain = profile.layers
-                    compress = profile.isCompressionEnabled
-                    addLog("Using Profile: ${profile.name}")
+                    // Raw mode assumes valid profile construction (single layer)
+                    val algo = profile.layers.firstOrNull() ?: CryptoEngine.Algorithm.AES_GCM
+
+                    addLog("Mode: Raw (${algo.name}).")
+                    result = CryptoEngine.encryptRaw(
+                        data = input.toByteArray(StandardCharsets.UTF_8),
+                        password = pwdChars,
+                        algorithm = algo,
+                        kdfConfig = kdfConfig,
+                        logCallback = { addLog(it) }
+                    )
                 } else {
-                    chain = state.customLayers.map { it.algorithm }
-                    compress = state.isCompressionEnabled
+                    // SIGIL CONTAINER (Auto or Custom)
+                    val chain: List<CryptoEngine.Algorithm>
+                    val compress: Boolean
+
+                    if (state.selectedMode == SigilMode.AUTO) {
+                        val profile = state.activeProfile
+                        chain = profile.layers
+                        compress = profile.isCompressionEnabled
+                        addLog("Using Profile: ${profile.name}")
+                    } else {
+                        chain = state.customLayers.map { it.algorithm }
+                        compress = state.isCompressionEnabled
+                    }
+
+                    if (chain.isEmpty()) throw Exception("No encryption layers selected.")
+
+                    result = CryptoEngine.encrypt(
+                        data = input.toByteArray(StandardCharsets.UTF_8),
+                        password = pwdChars,
+                        algorithms = chain,
+                        kdfConfig = kdfConfig,
+                        compress = compress,
+                        logCallback = { addLog(it) }
+                    )
                 }
 
-                if (chain.isEmpty()) throw Exception("No encryption layers selected.")
-
-                val result = CryptoEngine.encrypt(
-                    data = input.toByteArray(StandardCharsets.UTF_8),
-                    password = pwdChars,
-                    algorithms = chain,
-                    kdfConfig = kdfConfig,
-                    compress = compress,
-                    logCallback = { addLog(it) }
-                )
-
                 _uiState.update {
-                    if (it.selectedMode == SigilMode.AUTO) it.copy(
-                        autoOutput = result,
-                        isLoading = false
-                    )
+                    if (it.selectedMode == SigilMode.AUTO) it.copy(autoOutput = result, isLoading = false)
                     else it.copy(customOutput = result, isLoading = false)
                 }
             } catch (_: Exception) {
@@ -378,8 +406,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
 
     fun onDecrypt() {
         val state = _uiState.value
-        val pwdString =
-            if (state.selectedMode == SigilMode.AUTO) state.autoPassword else state.customPassword
+        val pwdString = if (state.selectedMode == SigilMode.AUTO) state.autoPassword else state.customPassword
         val input = if (state.selectedMode == SigilMode.AUTO) state.autoInput else state.customInput
 
         if (pwdString.isEmpty()) {
@@ -393,7 +420,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
 
         _uiState.update { it.copy(isLoading = true) }
 
-        // AGGRESSIVE WIPE: Clear password from UI immediately
+        // Wipe password from UI state
         _uiState.update {
             if (it.selectedMode == SigilMode.AUTO) it.copy(autoPassword = "")
             else it.copy(customPassword = "")
@@ -405,13 +432,30 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
             val pwdChars = pwdString.toCharArray()
             try {
                 val kdfConfig = getActiveKdfConfig()
+                val decryptedBytes: ByteArray
 
-                val decryptedBytes = CryptoEngine.decrypt(
-                    encryptedData = input,
-                    password = pwdChars,
-                    kdfConfig = kdfConfig,
-                    logCallback = { addLog(it) }
-                )
+                // CHECK FOR RAW PROFILE
+                if (state.selectedMode == SigilMode.AUTO && state.activeProfile.isRaw) {
+                    val profile = state.activeProfile
+                    val algo = profile.layers.firstOrNull() ?: CryptoEngine.Algorithm.AES_GCM
+
+                    addLog("Mode: Raw Decryption (${algo.name}). Expecting raw container.")
+                    decryptedBytes = CryptoEngine.decryptRaw(
+                        encryptedData = input,
+                        password = pwdChars,
+                        algorithm = algo,
+                        kdfConfig = kdfConfig,
+                        logCallback = { addLog(it) }
+                    )
+                } else {
+                    // SIGIL CONTAINER
+                    decryptedBytes = CryptoEngine.decrypt(
+                        encryptedData = input,
+                        password = pwdChars,
+                        kdfConfig = kdfConfig,
+                        logCallback = { addLog(it) }
+                    )
+                }
 
                 val decryptedString = String(decryptedBytes, StandardCharsets.UTF_8)
                 SecureMemory.wipe(decryptedBytes)
@@ -426,12 +470,17 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
 
             } catch (_: Exception) {
                 val errorReport = StringBuilder()
-                errorReport.append("DECRYPTION FAILED\n\n")
-                errorReport.append("POSSIBLE CAUSES:\n")
-                errorReport.append("1. Wrong password.\n")
-                errorReport.append("2. Corrupted data.\n")
-                errorReport.append("3. Security Settings Mismatch (Check KDF Iterations/Memory).\n")
-                errorReport.append("4. Profile Mismatch (If using custom KDF override).\n")
+                if (state.selectedMode == SigilMode.AUTO && state.activeProfile.isRaw) {
+                    errorReport.append("RAW DECRYPTION FAILED\n\n")
+                    errorReport.append("Raw mode has NO integrity checks. The password or profile is incorrect, or the data is garbage.")
+                } else {
+                    errorReport.append("DECRYPTION FAILED\n\n")
+                    errorReport.append("POSSIBLE CAUSES:\n")
+                    errorReport.append("1. Wrong password.\n")
+                    errorReport.append("2. Corrupted data.\n")
+                    errorReport.append("3. Security mismatch (Check KDF iterations/memory).\n")
+                    errorReport.append("4. Profile mismatch (Are you trying to decrypt Raw data with a Container profile?).\n")
+                }
 
                 val finalMessage = errorReport.toString()
 
@@ -443,7 +492,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
                     else it.copy(customOutput = finalMessage, isLoading = false)
                 }
 
-                addLog("Decryption Failed: Integrity check or Password mismatch.")
+                addLog("Decryption Failed.")
             } finally {
                 SecureMemory.wipe(pwdChars)
             }
@@ -689,34 +738,27 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    fun resetAppPreferences() {
-        // 1. Security & General
-        prefs.lockMode = LockMode.NONE
-        prefs.isGracePeriodEnabled = false
-        prefs.graceDurationMinutes = 5
-        prefs.isScreenShieldEnabled = true
-        prefs.clipboardTimeoutSeconds = 30
-        prefs.setOnboardingCompleted(false) // Reset Onboarding
+    fun resetAppPreferences(shouldRestart: Boolean) {
+        // 1. Reset Internal ViewModel State
+        setDemoMode(false)
 
-        // 2. Appearance
-        prefs.isDynamicColorsEnabled = true
-        prefs.isDarkModeEnabled = true
-        prefs.selectedThemeColor = 0xFFFFFFFF.toInt()
+        // 2. Reset Preferences
+        prefs.resetAllSettings(synchronous = shouldRestart)
 
-        // 3. KDF Defaults
-        prefs.kdfIterations = 10
-        prefs.kdfMemoryPow2 = 16
-        prefs.kdfParallelism = 4
+        addLog("Preferences reset to defaults.")
 
-        addLog("Preferences reset to defaults (Vault/Profiles preserved).")
+        // 3. Restart if requested
+        if (shouldRestart) {
+            val context = getApplication<Application>()
+            val packageManager = context.packageManager
+            val intent = packageManager.getLaunchIntentForPackage(context.packageName)
+            val componentName = intent?.component
+            val mainIntent = Intent.makeRestartActivityTask(componentName)
+            context.startActivity(mainIntent)
 
-        val context = getApplication<Application>()
-        val packageManager = context.packageManager
-        val intent = packageManager.getLaunchIntentForPackage(context.packageName)
-        val componentName = intent?.component
-        val mainIntent = Intent.makeRestartActivityTask(componentName)
-        context.startActivity(mainIntent)
-        exitProcess(0)
+            // Now safe to kill process because preferences are committed
+            exitProcess(0)
+        }
     }
 
     fun setDynamicColors(enabled: Boolean) { prefs.isDynamicColorsEnabled = enabled }
@@ -741,7 +783,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         // 1. Create ClipData
         val clip = ClipData.newPlainText(label, text)
 
-        // 2. Android 13+ Sensitive Flag (Prevents screenshot/preview of the clipboard overlay)
+        // 2. Android 13+ Sensitive Flag
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             clip.description.extras = PersistableBundle().apply {
                 putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
@@ -752,15 +794,15 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
 
         // 3. User Feedback & Timer
         val timeout = prefs.clipboardTimeoutSeconds
-        Toast.makeText(context, "Copied! Wiping in ${timeout}s", Toast.LENGTH_SHORT).show()
-        addLog("Sensitive data copied to clipboard.")
+
+        showBackgroundToast("Copied! Wiping in ${timeout}s")
+        addLog("Sensitive data copied. Wiping in ${timeout}s.")
 
         // 4. Schedule Auto-Wipe
         viewModelScope.launch(Dispatchers.Main) {
             delay(timeout * 1000L)
 
             try {
-
                 if (clipboard.hasPrimaryClip() && clipboard.primaryClipDescription?.label == label) {
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -769,7 +811,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
                         clipboard.setPrimaryClip(ClipData.newPlainText("", ""))
                     }
 
-                    Toast.makeText(context, "Sigil: Clipboard auto-wiped.", Toast.LENGTH_SHORT).show()
+                    showBackgroundToast("Sigil: Clipboard auto-wiped.")
                     addLog("Clipboard auto-wiped.")
                 }
             } catch (_: Exception) {

--- a/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
@@ -66,6 +66,11 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Displays a short Android Toast on the main thread, cancelling any previously shown toast.
+     *
+     * @param message The text to display in the toast.
+     */
     private fun showBackgroundToast(message: String) {
         viewModelScope.launch(Dispatchers.Main) {
             currentViewModelToast?.cancel()
@@ -75,7 +80,10 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    // --- PROFILE MANAGEMENT ---
+    /**
+     * Loads custom profiles from preferences, combines them with built-in profiles, selects the active profile
+     * (falling back to the default if the saved id is missing), and updates the UI state with the available and active profiles.
+     */
 
     private fun loadProfiles() {
         val customProfiles = prefs.getCustomProfiles()
@@ -92,12 +100,35 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Sets the given encryption profile as the application's active profile.
+     *
+     * Updates the persistent active profile preference, updates the UI state to reflect the selection,
+     * and records the profile switch in the view model logs.
+     *
+     * @param profile The EncryptionProfile to select as active.
+     */
     fun selectProfile(profile: EncryptionProfile) {
         prefs.activeProfileId = profile.id
         _uiState.update { it.copy(activeProfile = profile) }
         addLog("Profile Switched: ${profile.name}")
     }
 
+    /**
+     * Creates and persists a new custom encryption profile, then activates it.
+     *
+     * Validates that `name` is not blank and `layers` is not empty; if a profile with the same
+     * name (case-insensitive) already exists, the `onDuplicateName` callback is invoked instead.
+     *
+     * @param name The display name for the new profile.
+     * @param description Optional human-readable description for the profile.
+     * @param layers Ordered list of algorithms that form the encryption chain for this profile.
+     * @param kdfOverride Optional KDF configuration to use for this profile instead of the global KDF settings.
+     * @param compress Whether compression should be enabled when using this profile.
+     * @param isRaw If true, indicates the profile represents a raw single-layer mode rather than a container chain.
+     * @param onSuccess Callback invoked after the profile is saved and selected as the active profile.
+     * @param onDuplicateName Callback invoked with the existing conflicting profile when a duplicate name is detected.
+     */
     fun saveProfile(
         name: String,
         description: String,
@@ -145,6 +176,13 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         addLog("Profile Saved: $name")
     }
 
+    /**
+     * Replaces an existing custom encryption profile with the provided profile (matched by name, case-insensitive) and applies it as active.
+     *
+     * If a custom profile with the same name exists, this updates the stored custom profiles, reloads available profiles, selects the updated profile, and records a log entry.
+     *
+     * @param profile The encryption profile to save in place of an existing custom profile with the same name.
+     */
     fun overwriteProfile(profile: EncryptionProfile) {
         val currentCustom = prefs.getCustomProfiles().toMutableList()
         val index = currentCustom.indexOfFirst { it.name.equals(profile.name, ignoreCase = true) }
@@ -157,6 +195,14 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Deletes a custom encryption profile identified by `profileId`.
+     *
+     * If a matching custom profile exists it is removed from stored custom profiles, the profiles are reloaded,
+     * and the default profile is selected if the deleted profile was active. Also records a log entry when deletion occurs.
+     *
+     * @param profileId The identifier of the custom profile to delete.
+     */
     fun deleteProfile(profileId: String) {
         val currentCustom = prefs.getCustomProfiles().toMutableList()
         if (currentCustom.removeIf { it.id == profileId }) {
@@ -170,6 +216,11 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Resets custom encryption profiles to defaults.
+     *
+     * Clears all stored custom profiles, reloads the available profiles list, selects the built-in default profile, and records a log entry about the reset.
+     */
     fun resetProfiles() {
         prefs.saveCustomProfiles(emptyList())
         loadProfiles()
@@ -177,11 +228,21 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         addLog("All custom profiles cleared. Reset to defaults.")
     }
 
+    /**
+     * Retrieve an encryption profile by its identifier.
+     *
+     * @param id The profile identifier to look up.
+     * @return The matching `EncryptionProfile` if found, `null` otherwise.
+     */
     fun getProfileById(id: String): EncryptionProfile? {
         return _uiState.value.availableProfiles.find { it.id == id }
     }
 
-    // --- HELPER: KDF CONFIG INJECTION ---
+    /**
+     * Returns the effective KDF configuration: prefer an active profile's override when in AUTO mode, otherwise use global preferences.
+     *
+     * @return The `CryptoEngine.KdfConfig` from the active profile if available in AUTO mode; otherwise a config built from stored preferences (`prefs.kdfIterations`, `prefs.kdfMemoryPow2`, `prefs.kdfParallelism`).
+     */
     private fun getActiveKdfConfig(): CryptoEngine.KdfConfig {
         // 1. Check if ACTIVE PROFILE has an override
         if (_uiState.value.selectedMode == SigilMode.AUTO) {
@@ -228,7 +289,14 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    // --- NAVIGATION ---
+    /**
+     * Selects the active encryption mode and updates the UI state.
+     *
+     * When switching to SigilMode.CUSTOM, clears the current editing profile ID so no profile is considered
+     * being edited.
+     *
+     * @param mode The SigilMode to select; if `SigilMode.CUSTOM`, the editing profile ID is cleared.
+     */
     fun onModeSelected(mode: SigilMode) {
         _uiState.update {
             it.copy(
@@ -238,6 +306,14 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Load the given encryption profile into the custom editor and switch the UI to custom mode.
+     *
+     * Populates the custom layer list, applies the profile's compression setting, marks the profile as
+     * being edited, and records the action in the logs.
+     *
+     * @param profile The EncryptionProfile to load into the custom editor. 
+     */
     fun loadProfileToCustomMode(profile: EncryptionProfile) {
         _uiState.update {
             it.copy(
@@ -250,6 +326,11 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         addLog("Editing Profile: '${profile.name}'")
     }
 
+    /**
+     * Sets the active application screen in the view model's UI state.
+     *
+     * @param screen The screen to set as the current view.
+     */
     fun onScreenSelected(screen: AppScreen) {
         _uiState.update { it.copy(currentScreen = screen) }
     }
@@ -322,7 +403,11 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    // --- CRYPTO OPERATIONS ---
+    /**
+     * Encrypts the current input using the selected mode and updates the UI state with the resulting output.
+     *
+     * If the selected mode is AUTO and the active profile is marked RAW, performs a single-layer raw encryption using that profile's algorithm; otherwise builds and encrypts a Sigil container using the active profile's layers (AUTO) or the user-defined layers (CUSTOM). Requires a non-empty password; if the password is empty the operation is aborted and a log entry is added. While running, sets the view model loading flag and clears the password fields from the UI state. On completion or failure updates the appropriate output field and clears the loading flag, logs progress and errors, and securely wipes password memory.
+     */
     fun onEncrypt() {
         val state = _uiState.value
         val pwdString = if (state.selectedMode == SigilMode.AUTO) state.autoPassword else state.customPassword
@@ -404,6 +489,18 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Performs decryption of the currently selected input using the active profile and KDF settings.
+     *
+     * If no password or input is present, the method logs a message and returns without changing state.
+     * The UI loading state is set while decryption runs; the password is cleared from UI state immediately.
+     * Decryption runs on a background IO coroutine and:
+     * - Uses raw decryption when the active profile is marked `isRaw`, otherwise treats input as a Sigil container.
+     * - Writes the decrypted UTF-8 string to the appropriate output field (autoOutput or customOutput) and clears the loading flag on success.
+     * - On failure, writes a contextual, user-facing error message to the output and clears the loading flag.
+     *
+     * Sensitive data (password characters and decrypted bytes) is wiped from memory after use. Activity and errors are recorded via the view model's logging facility.
+     */
     fun onDecrypt() {
         val state = _uiState.value
         val pwdString = if (state.selectedMode == SigilMode.AUTO) state.autoPassword else state.customPassword
@@ -568,6 +665,15 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Loads the secret associated with a vault entry alias and delivers it to the caller.
+     *
+     * Updates the UI loading state while the vault is accessed and invokes `onResult` on the main thread
+     * with the secret value or `null` if the entry is not found.
+     *
+     * @param alias The vault entry alias to load.
+     * @param onResult Callback invoked with the secret value for `alias`, or `null` if unavailable.
+     */
     fun viewKey(alias: String, onResult: (String?) -> Unit) {
         _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch(Dispatchers.IO) {
@@ -688,6 +794,14 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
     }
 
 
+    /**
+     * Performs a full application data wipe and restarts the app.
+     *
+     * Deletes the app's shared preferences, removes entries from the Android Keystore,
+     * and deletes internal cache and files. After cleanup the app is restarted and the
+     * current process is terminated. Internal errors during wipe operations are caught
+     * and do not prevent the restart.
+     */
     fun wipeAllData() {
         // TRIGGER LOADING STATE
         _uiState.update { it.copy(isLoading = true) }
@@ -740,6 +854,13 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Resets application preferences and ViewModel internal state, and optionally restarts the app.
+     *
+     * This clears demo mode, resets all stored preferences to their defaults (committing them synchronously when a restart is requested), and appends a log entry. If `shouldRestart` is true, the application is restarted and the current process is terminated after preferences are committed.
+     *
+     * @param shouldRestart If true, commit preferences synchronously and restart the application process; otherwise perform a non-restarting reset.
+     */
     fun resetAppPreferences(shouldRestart: Boolean) {
         // 1. Reset Internal ViewModel State
         setDemoMode(false)
@@ -763,8 +884,25 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    fun setDynamicColors(enabled: Boolean) { prefs.isDynamicColorsEnabled = enabled }
-    fun setDarkMode(enabled: Boolean) { prefs.isDarkModeEnabled = enabled }
+    /**
+ * Toggle use of dynamic system-derived colors for the app theme.
+ *
+ * @param enabled `true` to enable dynamic colors (use system-derived palette), `false` to disable them (use app-defined colors).
+ */
+fun setDynamicColors(enabled: Boolean) { prefs.isDynamicColorsEnabled = enabled }
+    /**
+ * Sets whether the app should use dark theme.
+ *
+ * @param enabled `true` to enable dark mode, `false` to disable it.
+ */
+fun setDarkMode(enabled: Boolean) { prefs.isDarkModeEnabled = enabled }
+    /**
+     * Updates the application's selected theme color and persists it in preferences.
+     *
+     * The color is stored as an ARGB integer in persistent settings.
+     *
+     * @param color The new theme color to apply and save.
+     */
     fun setThemeColor(color: Color) {
         prefs.selectedThemeColor = color.toArgb()
     }
@@ -775,7 +913,18 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         return lockManager.hasPinSet()
     }
 
-    // --- CLIPBOARD SECURITY ---
+    /**
+     * Copy sensitive text to the system clipboard and schedule an automatic wipe.
+     *
+     * If `text` is blank the function returns immediately and does nothing. The copied clip
+     * is marked as sensitive on Android 13+ so the platform may treat it accordingly. A background
+     * toast and a log entry are produced when the text is copied and again when the clipboard is wiped.
+     * The clipboard is cleared after the configured clipboard timeout; exceptions raised during the
+     * wipe are ignored.
+     *
+     * @param text The sensitive text to copy to the clipboard.
+     * @param label A human-readable label for the clipboard entry; defaults to "Sigil Content".
+     */
     fun copyToClipboardSecurely(text: String, label: String = "Sigil Content") {
         if (text.isBlank()) return
 

--- a/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/SigilViewModel.kt
@@ -1,11 +1,11 @@
 package dev.animeshvarma.sigil
 
 import android.app.Application
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.ClipDescription
 import android.os.Build
 import android.os.PersistableBundle
 import android.widget.Toast
@@ -19,8 +19,10 @@ import dev.animeshvarma.sigil.data.KeystoreRepository
 import dev.animeshvarma.sigil.data.LockManager
 import dev.animeshvarma.sigil.data.VaultEntry
 import dev.animeshvarma.sigil.model.AppScreen
+import dev.animeshvarma.sigil.model.EncryptionProfile
 import dev.animeshvarma.sigil.model.LayerEntry
 import dev.animeshvarma.sigil.model.LockMode
+import dev.animeshvarma.sigil.model.ProfileRegistry
 import dev.animeshvarma.sigil.model.SigilMode
 import dev.animeshvarma.sigil.model.UiState
 import dev.animeshvarma.sigil.util.SecureMemory
@@ -36,6 +38,7 @@ import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.UUID
 import kotlin.system.exitProcess
 
 class SigilViewModel(application: Application) : AndroidViewModel(application) {
@@ -57,11 +60,127 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
     init {
         viewModelScope.launch(Dispatchers.IO) {
             refreshVault()
+            loadProfiles()
         }
     }
 
+    // --- PROFILE MANAGEMENT ---
+
+    private fun loadProfiles() {
+        val customProfiles = prefs.getCustomProfiles()
+        val allProfiles = ProfileRegistry.builtInProfiles + customProfiles
+        _uiState.update {
+            it.copy(availableProfiles = allProfiles)
+        }
+    }
+
+    fun selectProfile(profile: EncryptionProfile) {
+        _uiState.update { it.copy(activeProfile = profile) }
+        addLog("Profile Switched: ${profile.name}")
+    }
+
+    fun saveProfile(
+        name: String,
+        description: String,
+        layers: List<CryptoEngine.Algorithm>,
+        kdfOverride: CryptoEngine.KdfConfig?,
+        compress: Boolean,
+        onSuccess: () -> Unit,
+        onDuplicateName: (EncryptionProfile) -> Unit
+    ) {
+        if (name.isBlank()) {
+            addLog("Error: Profile name required.")
+            return
+        }
+        if (layers.isEmpty()) {
+            addLog("Error: Cannot save empty chain.")
+            return
+        }
+
+        val currentCustom = prefs.getCustomProfiles().toMutableList()
+
+        // Check for Name Duplication
+        val duplicate = currentCustom.find { it.name.equals(name, ignoreCase = true) }
+        if (duplicate != null) {
+            onDuplicateName(duplicate)
+            return
+        }
+
+        val newProfile = EncryptionProfile(
+            id = UUID.randomUUID().toString(),
+            name = name,
+            description = description,
+            layers = layers,
+            kdfConfig = kdfOverride,
+            isCompressionEnabled = compress,
+            isBuiltIn = false
+        )
+
+        currentCustom.add(newProfile)
+        prefs.saveCustomProfiles(currentCustom)
+        loadProfiles()
+        selectProfile(newProfile)
+        onSuccess()
+        addLog("Profile Saved: $name")
+    }
+
+    fun overwriteProfile(profile: EncryptionProfile) {
+        val currentCustom = prefs.getCustomProfiles().toMutableList()
+        val index = currentCustom.indexOfFirst { it.name.equals(profile.name, ignoreCase = true) }
+        if (index != -1) {
+            currentCustom[index] = profile
+            prefs.saveCustomProfiles(currentCustom)
+            loadProfiles()
+            selectProfile(profile)
+            addLog("Profile Updated: ${profile.name}")
+        }
+    }
+
+    fun deleteProfile(profileId: String) {
+        val currentCustom = prefs.getCustomProfiles().toMutableList()
+        if (currentCustom.removeIf { it.id == profileId }) {
+            prefs.saveCustomProfiles(currentCustom)
+            loadProfiles()
+            // Fallback to default if deleted was active
+            if (_uiState.value.activeProfile.id == profileId) {
+                selectProfile(ProfileRegistry.defaultProfile)
+            }
+            addLog("Profile Deleted.")
+        }
+    }
+
+    fun resetProfiles() {
+        prefs.saveCustomProfiles(emptyList())
+        loadProfiles()
+        selectProfile(ProfileRegistry.defaultProfile)
+        addLog("All custom profiles cleared. Reset to defaults.")
+    }
+
+    fun loadProfileToCustomMode(profile: EncryptionProfile) {
+        _uiState.update {
+            it.copy(
+                customLayers = profile.layers.map { algo -> LayerEntry(algorithm = algo) },
+                isCompressionEnabled = profile.isCompressionEnabled,
+                editingProfileId = profile.id,
+                selectedMode = SigilMode.CUSTOM
+            )
+        }
+        addLog("Editing Profile: '${profile.name}'")
+    }
+
+    fun getProfileById(id: String): EncryptionProfile? {
+        return _uiState.value.availableProfiles.find { it.id == id }
+    }
+
     // --- HELPER: KDF CONFIG INJECTION ---
-    private fun getUserKdfConfig(): CryptoEngine.KdfConfig {
+    private fun getActiveKdfConfig(): CryptoEngine.KdfConfig {
+        // 1. Check if ACTIVE PROFILE has an override
+        if (_uiState.value.selectedMode == SigilMode.AUTO) {
+            val profileKdf = _uiState.value.activeProfile.kdfConfig
+            if (profileKdf != null) return profileKdf
+        }
+
+        // 2. Fallback to Global Settings
         return CryptoEngine.KdfConfig(
             iterations = prefs.kdfIterations,
             memoryPow2 = prefs.kdfMemoryPow2,
@@ -102,7 +221,12 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
 
     // --- NAVIGATION ---
     fun onModeSelected(mode: SigilMode) {
-        _uiState.update { it.copy(selectedMode = mode) }
+        _uiState.update {
+            it.copy(
+                selectedMode = mode,
+                editingProfileId = if (mode == SigilMode.CUSTOM) null else it.editingProfileId
+            )
+        }
     }
 
     fun onScreenSelected(screen: AppScreen) {
@@ -205,17 +329,13 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
             try {
                 val chain: List<CryptoEngine.Algorithm>
                 val compress: Boolean
+                val kdfConfig = getActiveKdfConfig()
 
                 if (state.selectedMode == SigilMode.AUTO) {
-                    chain = listOf(
-                        CryptoEngine.Algorithm.AES_GCM,
-                        CryptoEngine.Algorithm.CHACHA20_POLY1305,
-                        CryptoEngine.Algorithm.TWOFISH_CBC,
-                        CryptoEngine.Algorithm.SERPENT_CBC
-                    ).shuffled()
-
-                    compress = true
-                    addLog("Auto Mode: 4-Layer Hybrid Chain (AES+ChaCha+Twofish+Serpent).")
+                    val profile = state.activeProfile
+                    chain = profile.layers
+                    compress = profile.isCompressionEnabled
+                    addLog("Using Profile: ${profile.name}")
                 } else {
                     chain = state.customLayers.map { it.algorithm }
                     compress = state.isCompressionEnabled
@@ -227,7 +347,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
                     data = input.toByteArray(StandardCharsets.UTF_8),
                     password = pwdChars,
                     algorithms = chain,
-                    kdfConfig = getUserKdfConfig(),
+                    kdfConfig = kdfConfig,
                     compress = compress,
                     logCallback = { addLog(it) }
                 )
@@ -276,10 +396,12 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch(Dispatchers.IO) {
             val pwdChars = pwdString.toCharArray()
             try {
+                val kdfConfig = getActiveKdfConfig()
+
                 val decryptedBytes = CryptoEngine.decrypt(
                     encryptedData = input,
                     password = pwdChars,
-                    kdfConfig = getUserKdfConfig(),
+                    kdfConfig = kdfConfig,
                     logCallback = { addLog(it) }
                 )
 
@@ -300,8 +422,8 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
                 errorReport.append("POSSIBLE CAUSES:\n")
                 errorReport.append("1. Wrong password.\n")
                 errorReport.append("2. Corrupted data.\n")
-                errorReport.append("3. Different Security Settings.\n")
-                errorReport.append("4. Legacy format (Sigil version < v0.4.5).\n")
+                errorReport.append("3. Security Settings Mismatch (Check KDF Iterations/Memory).\n")
+                errorReport.append("4. Profile Mismatch (If using custom KDF override).\n")
 
                 val finalMessage = errorReport.toString()
 
@@ -398,7 +520,7 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-// --- DEMO / ONBOARDING CONTROL ---
+    // --- DEMO / ONBOARDING CONTROL ---
     // 1. Control the Docs Tab programmatically
     private val _demoDocsTabIndex = MutableStateFlow(0)
     val demoDocsTabIndex: StateFlow<Int> = _demoDocsTabIndex
@@ -557,6 +679,36 @@ class SigilViewModel(application: Application) : AndroidViewModel(application) {
                 exitProcess(0)
             }
         }
+    }
+
+    fun resetAppPreferences() {
+        // 1. Security & General
+        prefs.lockMode = LockMode.NONE
+        prefs.isGracePeriodEnabled = false
+        prefs.graceDurationMinutes = 5
+        prefs.isScreenShieldEnabled = true
+        prefs.clipboardTimeoutSeconds = 30
+        prefs.setOnboardingCompleted(false) // Reset Onboarding
+
+        // 2. Appearance
+        prefs.isDynamicColorsEnabled = true
+        prefs.isDarkModeEnabled = true
+        prefs.selectedThemeColor = 0xFFFFFFFF.toInt()
+
+        // 3. KDF Defaults
+        prefs.kdfIterations = 10
+        prefs.kdfMemoryPow2 = 16
+        prefs.kdfParallelism = 4
+
+        addLog("Preferences reset to defaults (Vault/Profiles preserved).")
+
+        val context = getApplication<Application>()
+        val packageManager = context.packageManager
+        val intent = packageManager.getLaunchIntentForPackage(context.packageName)
+        val componentName = intent?.component
+        val mainIntent = Intent.makeRestartActivityTask(componentName)
+        context.startActivity(mainIntent)
+        exitProcess(0)
     }
 
     fun setDynamicColors(enabled: Boolean) { prefs.isDynamicColorsEnabled = enabled }

--- a/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
@@ -99,7 +99,7 @@ object CryptoEngine {
 
         // 2. Root Secret (Argon2id)
         val passBytes = toBytes(password)
-        val rootSecret = deriveRootSecret(passBytes, salt, kdfConfig)
+        val rootSecret = deriveKeyArgon2(passBytes, salt, kdfConfig, 32)
         passBytes.fill(0.toByte())
 
         logCallback("Root Secret derived (Argon2id: ${kdfConfig.memoryPow2} pow2 memory, ${kdfConfig.iterations} iterations).")
@@ -179,6 +179,7 @@ object CryptoEngine {
         return stripPadding(encoder.encodeToString(finalBytes))
     }
 
+    // --- MAIN CHAIN DECRYPTION ---
     fun decrypt(
         encryptedData: String,
         password: CharArray,
@@ -212,7 +213,7 @@ object CryptoEngine {
 
             // Reconstruct Root
             val passBytes = toBytes(password)
-            rootSecret = deriveRootSecret(passBytes, salt, kdfConfig)
+            rootSecret = deriveKeyArgon2(passBytes, salt, kdfConfig, 32)
             passBytes.fill(0.toByte())
             logCallback("Root Secret reconstructed (Argon2id: ${kdfConfig.memoryPow2} pow2 memory, ${kdfConfig.iterations} iterations).")
 
@@ -282,6 +283,93 @@ object CryptoEngine {
             throw IllegalArgumentException(genericError)
         } finally {
             rootSecret?.fill(0.toByte())
+        }
+    }
+
+    // --- RAW / STANDALONE MODE ---
+    fun encryptRaw(
+        data: ByteArray,
+        password: CharArray,
+        algorithm: Algorithm,
+        kdfConfig: KdfConfig,
+        logCallback: (String) -> Unit = {}
+    ): String {
+        require(data.size <= MAX_DATA_LIMIT) { "Input exceeds 10MB safety limit." }
+
+        val startTime = System.currentTimeMillis()
+        logCallback("Starting Raw Encryption (${algorithm.name})...")
+
+        // 1. Generate Salt
+        val salt = ByteArray(16).apply { secureRandom.nextBytes(this) }
+
+        // 2. Generate IV (Dynamic Size)
+        val ivSize = getIvSize(algorithm)
+        val iv = ByteArray(ivSize).apply { secureRandom.nextBytes(this) }
+
+        // 3. Derive Key (Argon2id direct to Key Size)
+        val keySize = getKeySize(algorithm)
+        val passBytes = toBytes(password)
+        val key = deriveKeyArgon2(passBytes, salt, kdfConfig, keySize)
+        passBytes.fill(0.toByte())
+
+        logCallback("Key derived (Argon2id).")
+
+        // 4. Encrypt using generalized processor
+        val ciphertext = processCipher(true, algorithm, data, key, iv)
+        key.fill(0.toByte())
+
+        // 5. Pack (Salt + IV + Ciphertext)
+        val output = ByteBuffer.allocate(salt.size + iv.size + ciphertext.size)
+            .put(salt)
+            .put(iv)
+            .put(ciphertext)
+            .array()
+
+        logCallback("Raw Encryption complete in ${System.currentTimeMillis() - startTime}ms.")
+
+        return encoder.encodeToString(output)
+    }
+
+    fun decryptRaw(
+        encryptedData: String,
+        password: CharArray,
+        algorithm: Algorithm,
+        kdfConfig: KdfConfig,
+        logCallback: (String) -> Unit = {}
+    ): ByteArray {
+        val startTime = System.currentTimeMillis()
+        logCallback("Reading Raw Container...")
+
+        try {
+            // 1. Decode
+            val cleanData = encryptedData.filter { !it.isWhitespace() }
+            val rawBytes = decoder.decode(cleanData)
+
+            val ivSize = getIvSize(algorithm)
+            val minSize = 16 + ivSize // Salt + IV
+            if (rawBytes.size <= minSize) throw IllegalArgumentException("Invalid data size.")
+
+            // 2. Unpack
+            val buffer = ByteBuffer.wrap(rawBytes)
+            val salt = ByteArray(16); buffer.get(salt)
+            val iv = ByteArray(ivSize); buffer.get(iv)
+            val ciphertext = ByteArray(buffer.remaining()); buffer.get(ciphertext)
+
+            // 3. Derive Key
+            val keySize = getKeySize(algorithm)
+            val passBytes = toBytes(password)
+            val key = deriveKeyArgon2(passBytes, salt, kdfConfig, keySize)
+            passBytes.fill(0.toByte())
+
+            // 4. Decrypt
+            val plaintext = processCipher(false, algorithm, ciphertext, key, iv)
+            key.fill(0.toByte())
+
+            logCallback("Decryption complete in ${System.currentTimeMillis() - startTime}ms.")
+            return plaintext
+
+        } catch (_: Exception) {
+            throw IllegalArgumentException("Raw Decryption failed. Wrong password, profile, or data corruption.")
         }
     }
 
@@ -357,8 +445,7 @@ object CryptoEngine {
 
     private fun stripPadding(i: String) = i.trimEnd('=')
     private fun restorePadding(i: String): String { val m = i.length % 4; return if (m > 0) i + "=".repeat(4 - m) else i }
-
-    private fun deriveRootSecret(p: ByteArray, s: ByteArray, config: KdfConfig): ByteArray {
+    private fun deriveKeyArgon2(p: ByteArray, s: ByteArray, config: KdfConfig, length: Int): ByteArray {
         val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
             .withVersion(Argon2Parameters.ARGON2_VERSION_13)
             .withIterations(config.iterations)
@@ -368,8 +455,8 @@ object CryptoEngine {
             .build()
         val g = Argon2BytesGenerator()
         g.init(params)
-        val r = ByteArray(32)
-        g.generateBytes(p, r, 0, 32)
+        val r = ByteArray(length)
+        g.generateBytes(p, r, 0, length)
         return r
     }
 

--- a/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
@@ -437,6 +437,7 @@ object CryptoEngine {
      * @param pin The PIN to hash; the function will clear the PIN contents after use.
      * @param salt The salt bytes to use for derivation.
      * @return A 32-byte derived hash.
+     */
     fun hashPin(pin: CharArray, salt: ByteArray): ByteArray {
         val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
             .withVersion(Argon2Parameters.ARGON2_VERSION_13)

--- a/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
@@ -126,8 +126,11 @@ object CryptoEngine {
 
         // 2. Root Secret (Argon2id)
         val passBytes = toBytes(password)
-        val rootSecret = deriveKeyArgon2(passBytes, salt, kdfConfig, 32)
-        passBytes.fill(0.toByte())
+        val rootSecret = try {
+            deriveKeyArgon2(passBytes, salt, kdfConfig, 32)
+        } finally {
+            passBytes.fill(0.toByte())
+        }
 
         logCallback("Root Secret derived (Argon2id: ${kdfConfig.memoryPow2} pow2 memory, ${kdfConfig.iterations} iterations).")
 
@@ -255,8 +258,11 @@ object CryptoEngine {
 
             // Reconstruct Root
             val passBytes = toBytes(password)
-            rootSecret = deriveKeyArgon2(passBytes, salt, kdfConfig, 32)
-            passBytes.fill(0.toByte())
+            rootSecret = try {
+                deriveKeyArgon2(passBytes, salt, kdfConfig, 32)
+            } finally {
+                passBytes.fill(0.toByte())
+            }
             logCallback("Root Secret reconstructed (Argon2id: ${kdfConfig.memoryPow2} pow2 memory, ${kdfConfig.iterations} iterations).")
 
             val macKey = deriveSubKey(rootSecret, salt, "SIGIL_GLOBAL_MAC", 32)
@@ -368,8 +374,11 @@ object CryptoEngine {
         // 3. Derive Key (Argon2id direct to Key Size)
         val keySize = getKeySize(algorithm)
         val passBytes = toBytes(password)
-        val key = deriveKeyArgon2(passBytes, salt, kdfConfig, keySize)
-        passBytes.fill(0.toByte())
+        val key = try {
+            deriveKeyArgon2(passBytes, salt, kdfConfig, keySize)
+        } finally {
+            passBytes.fill(0.toByte())
+        }
 
         logCallback("Key derived (Argon2id).")
 
@@ -439,8 +448,11 @@ object CryptoEngine {
             // 3. Derive Key
             val keySize = getKeySize(algorithm)
             val passBytes = toBytes(password)
-            val key = deriveKeyArgon2(passBytes, salt, kdfConfig, keySize)
-            passBytes.fill(0.toByte())
+            val key = try {
+                deriveKeyArgon2(passBytes, salt, kdfConfig, keySize)
+            } finally {
+                passBytes.fill(0.toByte())
+            }
 
             // 4. Decrypt
             val plaintext = try {

--- a/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
@@ -334,6 +334,10 @@ object CryptoEngine {
      * The returned container is Base64-encoded and contains, in order: 16-byte salt, IV (algorithm-dependent size),
      * and the ciphertext produced by the chosen algorithm.
      *
+     * **SECURITY WARNING:** Unlike the standard [encrypt] method, this function does NOT apply a global HMAC.
+     * If [algorithm] is not an AEAD cipher (e.g. CBC modes), the resulting ciphertext lacks integrity protection.
+     * Malicious modification of the ciphertext will not be detected during decryption. This is intended for educational purposes.
+     *
      * @param data Plaintext bytes to encrypt (must be <= 10MB).
      * @param password Password as a CharArray; its UTF-8 bytes are derived and cleared after use.
      * @param algorithm Cipher algorithm to use for encryption and IV/key sizing.
@@ -392,6 +396,10 @@ object CryptoEngine {
 
     /**
      * Decrypts a standalone raw container produced by encryptRaw.
+     *
+     * **SECURITY WARNING:** If the data was encrypted using a non-AEAD algorithm (e.g. CBC modes),
+     * this method cannot verify the integrity of the ciphertext. Tampered data may result in garbage
+     * output rather than a validation error. This is intended for educational purposes.
      *
      * @param encryptedData Base64-encoded container string (whitespace allowed) containing salt, IV, and ciphertext.
      * @param password Password as a CharArray used to derive the decryption key; the function clears this input internally.

--- a/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
@@ -80,6 +80,23 @@ object CryptoEngine {
         }
     }
 
+    /**
+     * Encrypts a byte array with a layered sequence of authenticated ciphers and returns a compact Base64 string.
+     *
+     * Applies Argon2id-based key derivation from the provided password and a random salt, optionally compresses
+     * the plaintext, encrypts the payload through the given algorithm chain (in order), stores per-layer IVs and
+     * metadata in an AES-GCM-protected header, and appends a global HMAC. The final result is Base64-encoded with
+     * padding removed.
+     *
+     * @param data Plaintext bytes to encrypt (must be ≤ 10 MB).
+     * @param password Password characters used to derive keys; the implementation clears this buffer after use.
+     * @param algorithms Ordered list of algorithms to apply as layered encryption (default: AES_GCM).
+     * @param kdfConfig Argon2id parameters (iterations, memoryPow2, parallelism) used for key derivation.
+     * @param compress If true, compresses the plaintext before encryption.
+     * @param logCallback Optional callback that receives progress, warning, and timing messages.
+     * @return A Base64-encoded string (padding stripped) containing salt, encrypted header, ciphertext, and HMAC.
+     * @throws IllegalArgumentException If input, intermediate pack, or final output sizes exceed configured safety limits.
+     */
     fun encrypt(
         data: ByteArray,
         password: CharArray,
@@ -179,7 +196,22 @@ object CryptoEngine {
         return stripPadding(encoder.encodeToString(finalBytes))
     }
 
-    // --- MAIN CHAIN DECRYPTION ---
+    /**
+     * Decrypts a secure container produced by this engine and returns the original plaintext bytes.
+     *
+     * Performs Argon2id key derivation using the provided password and kdfConfig, verifies a global
+     * HMAC to ensure integrity, decrypts the layered cipher sequence stored in the container, and
+     * optionally decompresses the final payload when indicated by the metadata. Sensitive keying
+     * material derived during the operation is cleared from memory before returning.
+     *
+     * @param encryptedData Base64-encoded container string produced by the corresponding encrypt routine.
+     * @param password The password as a mutable CharArray; contents are zeroed after use.
+     * @param kdfConfig Argon2id parameter set used to reconstruct key material.
+     * @return The decrypted plaintext bytes.
+     * @throws IllegalArgumentException If decryption fails for any reason (integrity check, malformed
+     *     input, wrong password, or other errors). The exception message is intentionally generic to
+     *     avoid leaking sensitive information.
+     */
     fun decrypt(
         encryptedData: String,
         password: CharArray,
@@ -286,7 +318,20 @@ object CryptoEngine {
         }
     }
 
-    // --- RAW / STANDALONE MODE ---
+    /**
+     * Encrypts a single byte payload with the specified algorithm and returns a compact raw container.
+     *
+     * The returned container is Base64-encoded and contains, in order: 16-byte salt, IV (algorithm-dependent size),
+     * and the ciphertext produced by the chosen algorithm.
+     *
+     * @param data Plaintext bytes to encrypt (must be <= 10MB).
+     * @param password Password as a CharArray; its UTF-8 bytes are derived and cleared after use.
+     * @param algorithm Cipher algorithm to use for encryption and IV/key sizing.
+     * @param kdfConfig Argon2id parameters used to derive the encryption key.
+     * @param logCallback Optional callback receiving progress/log messages.
+     * @return A Base64-encoded string containing salt || iv || ciphertext.
+     * @throws IllegalArgumentException If `data` exceeds the 10MB safety limit.
+     */
     fun encryptRaw(
         data: ByteArray,
         password: CharArray,
@@ -330,6 +375,17 @@ object CryptoEngine {
         return encoder.encodeToString(output)
     }
 
+    /**
+     * Decrypts a standalone raw container produced by encryptRaw.
+     *
+     * @param encryptedData Base64-encoded container string (whitespace allowed) containing salt, IV, and ciphertext.
+     * @param password Password as a CharArray used to derive the decryption key; the function clears this input internally.
+     * @param algorithm The Algorithm that was used to encrypt the container.
+     * @param kdfConfig Argon2id parameters used for key derivation.
+     * @param logCallback Optional logging function that receives progress messages.
+     * @return The decrypted plaintext bytes.
+     * @throws IllegalArgumentException If decoding, key derivation, or decryption fails (e.g., wrong password/profile or data corruption).
+     */
     fun decryptRaw(
         encryptedData: String,
         password: CharArray,
@@ -373,7 +429,14 @@ object CryptoEngine {
         }
     }
 
-    // --- SECURE HELPERS ---
+    /**
+     * Derives a 32-byte Argon2id hash from a PIN and salt.
+     *
+     * The function uses fixed Argon2id parameters to produce a 32-byte key from the provided PIN and salt.
+     *
+     * @param pin The PIN to hash; the function will clear the PIN contents after use.
+     * @param salt The salt bytes to use for derivation.
+     * @return A 32-byte derived hash.
     fun hashPin(pin: CharArray, salt: ByteArray): ByteArray {
         val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
             .withVersion(Argon2Parameters.ARGON2_VERSION_13)
@@ -443,8 +506,31 @@ object CryptoEngine {
         return outputStream.toByteArray()
     }
 
-    private fun stripPadding(i: String) = i.trimEnd('=')
-    private fun restorePadding(i: String): String { val m = i.length % 4; return if (m > 0) i + "=".repeat(4 - m) else i }
+    /**
+ * Removes Base64 padding characters from the end of a string.
+ *
+ * @param i The input string (typically Base64-encoded) from which trailing `=` characters should be removed.
+ * @return The input string with all trailing `=` characters removed.
+ */
+private fun stripPadding(i: String) = i.trimEnd('=')
+    /**
+ * Restores Base64 padding so the input's length becomes a multiple of four.
+ *
+ * @param i A Base64-encoded string that may have had trailing '=' padding removed.
+ * @return The input string with '=' characters appended as needed to reach a length divisible by 4.
+ */
+private fun restorePadding(i: String): String { val m = i.length % 4; return if (m > 0) i + "=".repeat(4 - m) else i }
+    /**
+     * Derives a fixed-length key from password bytes and a salt using Argon2id with the provided KDF parameters.
+     *
+     * Uses Argon2id (version 1.3) and the iterations, memory, and parallelism from [config] to produce a key of the requested length.
+     *
+     * @param p Password-derived input bytes (will be used as Argon2 input).
+     * @param s Salt bytes to use for derivation.
+     * @param config Argon2id parameter set (iterations, memoryPow2, parallelism).
+     * @param length Desired length of the derived key in bytes.
+     * @return A byte array of size `length` containing the derived key.
+     */
     private fun deriveKeyArgon2(p: ByteArray, s: ByteArray, config: KdfConfig, length: Int): ByteArray {
         val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
             .withVersion(Argon2Parameters.ARGON2_VERSION_13)

--- a/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/crypto/CryptoEngine.kt
@@ -52,6 +52,16 @@ object CryptoEngine {
         BLOWFISH_CBC, IDEA_CBC, CAST5_CBC, TEA_CBC, XTEA_CBC, GOST_CBC
     }
 
+    fun isAEAD(algo: Algorithm): Boolean {
+        return when (algo) {
+            Algorithm.AES_GCM,
+            Algorithm.CHACHA20_POLY1305,
+            Algorithm.XCHACHA20_POLY1305,
+            Algorithm.ARIA_256_GCM -> true
+            else -> false
+        }
+    }
+
     private fun getIvSize(algo: Algorithm): Int {
         return when (algo) {
             Algorithm.AES_GCM, Algorithm.CHACHA20_POLY1305, Algorithm.ARIA_256_GCM -> 12
@@ -328,7 +338,7 @@ object CryptoEngine {
      * @param password Password as a CharArray; its UTF-8 bytes are derived and cleared after use.
      * @param algorithm Cipher algorithm to use for encryption and IV/key sizing.
      * @param kdfConfig Argon2id parameters used to derive the encryption key.
-     * @param logCallback Optional callback receiving progress/log messages.
+     * @param logCallback Optional logging function receiving progress/log messages.
      * @return A Base64-encoded string containing salt || iv || ciphertext.
      * @throws IllegalArgumentException If `data` exceeds the 10MB safety limit.
      */
@@ -360,8 +370,11 @@ object CryptoEngine {
         logCallback("Key derived (Argon2id).")
 
         // 4. Encrypt using generalized processor
-        val ciphertext = processCipher(true, algorithm, data, key, iv)
-        key.fill(0.toByte())
+        val ciphertext = try {
+            processCipher(true, algorithm, data, key, iv)
+        } finally {
+            key.fill(0.toByte())
+        }
 
         // 5. Pack (Salt + IV + Ciphertext)
         val output = ByteBuffer.allocate(salt.size + iv.size + ciphertext.size)
@@ -369,6 +382,8 @@ object CryptoEngine {
             .put(iv)
             .put(ciphertext)
             .array()
+
+        require(output.size <= MAX_DATA_LIMIT) { "Output exceeds 10MB safety limit." }
 
         logCallback("Raw Encryption complete in ${System.currentTimeMillis() - startTime}ms.")
 
@@ -401,6 +416,8 @@ object CryptoEngine {
             val cleanData = encryptedData.filter { !it.isWhitespace() }
             val rawBytes = decoder.decode(cleanData)
 
+            if (rawBytes.size > MAX_DATA_LIMIT) throw IllegalArgumentException("Input exceeds 10MB safety limit.")
+
             val ivSize = getIvSize(algorithm)
             val minSize = 16 + ivSize // Salt + IV
             if (rawBytes.size <= minSize) throw IllegalArgumentException("Invalid data size.")
@@ -418,8 +435,11 @@ object CryptoEngine {
             passBytes.fill(0.toByte())
 
             // 4. Decrypt
-            val plaintext = processCipher(false, algorithm, ciphertext, key, iv)
-            key.fill(0.toByte())
+            val plaintext = try {
+                processCipher(false, algorithm, ciphertext, key, iv)
+            } finally {
+                key.fill(0.toByte())
+            }
 
             logCallback("Decryption complete in ${System.currentTimeMillis() - startTime}ms.")
             return plaintext
@@ -508,19 +528,19 @@ object CryptoEngine {
     }
 
     /**
- * Removes Base64 padding characters from the end of a string.
- *
- * @param i The input string (typically Base64-encoded) from which trailing `=` characters should be removed.
- * @return The input string with all trailing `=` characters removed.
- */
-private fun stripPadding(i: String) = i.trimEnd('=')
+     * Removes Base64 padding characters from the end of a string.
+     *
+     * @param i The input string (typically Base64-encoded) from which trailing `=` characters should be removed.
+     * @return The input string with all trailing `=` characters removed.
+     */
+    private fun stripPadding(i: String) = i.trimEnd('=')
     /**
- * Restores Base64 padding so the input's length becomes a multiple of four.
- *
- * @param i A Base64-encoded string that may have had trailing '=' padding removed.
- * @return The input string with '=' characters appended as needed to reach a length divisible by 4.
- */
-private fun restorePadding(i: String): String { val m = i.length % 4; return if (m > 0) i + "=".repeat(4 - m) else i }
+     * Restores Base64 padding so the input's length becomes a multiple of four.
+     *
+     * @param i A Base64-encoded string that may have had trailing '=' padding removed.
+     * @return The input string with '=' characters appended as needed to reach a length divisible by 4.
+     */
+    private fun restorePadding(i: String): String { val m = i.length % 4; return if (m > 0) i + "=".repeat(4 - m) else i }
     /**
      * Derives a fixed-length key from password bytes and a salt using Argon2id with the provided KDF parameters.
      *

--- a/app/src/main/java/dev/animeshvarma/sigil/model/SigilTypes.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/model/SigilTypes.kt
@@ -35,7 +35,6 @@ data class SigilAlgorithm(
     val description: String,
     val type: CipherType,
     val defaultMode: CipherMode,
-    // SECURITY INDICATORS
     val isWeak: Boolean = false,
     val securityWarning: String? = null
 )
@@ -47,10 +46,13 @@ data class EncryptionProfile(
     val layers: List<CryptoEngine.Algorithm>,
     val kdfConfig: CryptoEngine.KdfConfig? = null,
     val isBuiltIn: Boolean = false,
-    val isCompressionEnabled: Boolean = true
+    val isCompressionEnabled: Boolean = true,
+    val isRaw: Boolean = false
 )
 
 object ProfileRegistry {
+    const val STANDARD_AES_ID = "sigil_standard_aes"
+
     val defaultProfile = EncryptionProfile(
         id = "sigil_default_chain",
         name = "Sigil Chain",
@@ -62,16 +64,18 @@ object ProfileRegistry {
             CryptoEngine.Algorithm.AES_GCM
         ),
         isBuiltIn = true,
-        isCompressionEnabled = true
+        isCompressionEnabled = true,
+        isRaw = false
     )
 
     val standardProfile = EncryptionProfile(
-        id = "sigil_standard_aes",
+        id = STANDARD_AES_ID,
         name = "Standard AES",
-        description = "Fast, hardware-accelerated AES-256-GCM. Industry standard.",
+        description = "Standalone AES-256-GCM. No chaining, no headers, no metadata. For other raw algorithms, use Custom tab. Auto-decrypt unsupported; requires manual profile selection.",
         layers = listOf(CryptoEngine.Algorithm.AES_GCM),
         isBuiltIn = true,
-        isCompressionEnabled = true
+        isCompressionEnabled = false,
+        isRaw = true
     )
 
     val builtInProfiles = listOf(defaultProfile, standardProfile)
@@ -230,30 +234,19 @@ data class UiState(
     val autoInput: String = "",
     val autoPassword: String = "",
     val autoOutput: String = "",
-
     val customInput: String = "",
     val customPassword: String = "",
     val customOutput: String = "",
-
     val selectedMode: SigilMode = SigilMode.AUTO,
     val currentScreen: AppScreen = AppScreen.HOME,
     val logs: List<String> = emptyList(),
     val isLoading: Boolean = false,
     val showLogsDialog: Boolean = false,
-
-    // Profile Management
     val availableProfiles: List<EncryptionProfile> = ProfileRegistry.builtInProfiles,
     val activeProfile: EncryptionProfile = ProfileRegistry.defaultProfile,
-
     val editingProfileId: String? = null,
-
-    // Demo Controls
     val isDemoDropdownExpanded: Boolean = false,
     val isDemoDrawerOpen: Boolean = false,
-
-    val customLayers: List<LayerEntry> = listOf(
-        LayerEntry(algorithm = CryptoEngine.Algorithm.AES_GCM)
-    ),
-
+    val customLayers: List<LayerEntry> = listOf(LayerEntry(algorithm = CryptoEngine.Algorithm.AES_GCM)),
     val isCompressionEnabled: Boolean = true
 )

--- a/app/src/main/java/dev/animeshvarma/sigil/model/SigilTypes.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/model/SigilTypes.kt
@@ -40,6 +40,43 @@ data class SigilAlgorithm(
     val securityWarning: String? = null
 )
 
+data class EncryptionProfile(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val description: String,
+    val layers: List<CryptoEngine.Algorithm>,
+    val kdfConfig: CryptoEngine.KdfConfig? = null,
+    val isBuiltIn: Boolean = false,
+    val isCompressionEnabled: Boolean = true
+)
+
+object ProfileRegistry {
+    val defaultProfile = EncryptionProfile(
+        id = "sigil_default_chain",
+        name = "Sigil Chain",
+        description = "Sigil's hybrid stack. XChaCha20 + Serpent + Twofish + AES.",
+        layers = listOf(
+            CryptoEngine.Algorithm.XCHACHA20_POLY1305,
+            CryptoEngine.Algorithm.SERPENT_CBC,
+            CryptoEngine.Algorithm.TWOFISH_CBC,
+            CryptoEngine.Algorithm.AES_GCM
+        ),
+        isBuiltIn = true,
+        isCompressionEnabled = true
+    )
+
+    val standardProfile = EncryptionProfile(
+        id = "sigil_standard_aes",
+        name = "Standard AES",
+        description = "Fast, hardware-accelerated AES-256-GCM. Industry standard.",
+        layers = listOf(CryptoEngine.Algorithm.AES_GCM),
+        isBuiltIn = true,
+        isCompressionEnabled = true
+    )
+
+    val builtInProfiles = listOf(defaultProfile, standardProfile)
+}
+
 object AlgorithmRegistry {
     val supportedAlgorithms = listOf(
         SigilAlgorithm(
@@ -203,6 +240,12 @@ data class UiState(
     val logs: List<String> = emptyList(),
     val isLoading: Boolean = false,
     val showLogsDialog: Boolean = false,
+
+    // Profile Management
+    val availableProfiles: List<EncryptionProfile> = ProfileRegistry.builtInProfiles,
+    val activeProfile: EncryptionProfile = ProfileRegistry.defaultProfile,
+
+    val editingProfileId: String? = null,
 
     // Demo Controls
     val isDemoDropdownExpanded: Boolean = false,

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/SigilApp.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/SigilApp.kt
@@ -35,6 +35,20 @@ import dev.animeshvarma.sigil.ui.screens.SteganographyScreen
 import dev.animeshvarma.sigil.ui.theme.AnimationConfig
 import kotlinx.coroutines.launch
 
+/**
+ * Hosts the app's top-level UI, wiring SigilViewModel state to the navigation drawer, header,
+ * screen content, loading overlay, and logs dialog.
+ *
+ * Observes `viewModel.uiState` and:
+ * - Renders a ModalNavigationDrawer whose content and open/close state reflect UI state.
+ * - Shows a centered header with a menu button that opens the drawer.
+ * - Switches main content between app screens with an animated transition.
+ * - Overlays a non-interactive loading scrim while a loading flag is set.
+ * - Displays an in-app logs dialog when requested.
+ *
+ * @param modifier Modifier applied to the root container.
+ * @param viewModel ViewModel that provides UI state and handles navigation and actions. 
+ */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun SigilApp(

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/SigilApp.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/SigilApp.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.*
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -151,7 +152,10 @@ fun SigilApp(
                     modifier = Modifier
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f))
-                        .clickable(enabled = false) {},
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null
+                        ) {},
                     contentAlignment = Alignment.Center
                 ) {
                     LoadingIndicator(

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/SigilApp.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/SigilApp.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.animeshvarma.sigil.SigilViewModel
 import dev.animeshvarma.sigil.model.AppScreen
 import dev.animeshvarma.sigil.model.SigilMode
@@ -40,7 +41,8 @@ fun SigilApp(
     modifier: Modifier = Modifier,
     viewModel: SigilViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
 
@@ -49,7 +51,6 @@ fun SigilApp(
         if (uiState.isDemoDrawerOpen) {
             drawerState.open()
         } else {
-            // Only close if it's actually open to avoid state thrashing
             if (drawerState.isOpen) drawerState.close()
         }
     }
@@ -110,7 +111,6 @@ fun SigilApp(
                                 stiffness = AnimationConfig.STIFFNESS,
                                 dampingRatio = AnimationConfig.DAMPING
                             )
-                            // Physics-based transition: Scale + Fade
                             (fadeIn(animationSpec = screenSpring) + scaleIn(initialScale = 0.95f, animationSpec = screenSpring))
                                 .togetherWith(fadeOut(animationSpec = screenSpring) + scaleOut(targetScale = 1.05f, animationSpec = screenSpring))
                         },
@@ -122,7 +122,6 @@ fun SigilApp(
                             AppScreen.STEGANOGRAPHY -> SteganographyScreen()
                             AppScreen.KEYSTORE -> KeystoreScreen(viewModel)
                             AppScreen.SETTINGS -> SettingsScreen(viewModel)
-                            // Feature Flags: Render "Under Construction" for v0.5 modules
                             AppScreen.HEADERLESS,
                             AppScreen.FILE_ENCRYPTION,
                             AppScreen.ASYMMETRIC,
@@ -133,13 +132,12 @@ fun SigilApp(
                 }
             }
 
-            // The Expressive Shape-Shifting Loader (Requires Material3 1.5.0-alpha11+)
             if (uiState.isLoading) {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f))
-                        .clickable(enabled = false) {}, // Block clicks
+                        .clickable(enabled = false) {},
                     contentAlignment = Alignment.Center
                 ) {
                     LoadingIndicator(

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/components/SecurePasswordInput.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/components/SecurePasswordInput.kt
@@ -30,6 +30,22 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.animeshvarma.sigil.data.VaultEntry
 
+/**
+ * A composable password/key input with visibility toggle, integrated vault dropdown, and save/overwrite flows.
+ *
+ * Shows an outlined text field for entering a password or key, a trailing visibility toggle, and a vault menu
+ * that lets the user save the current value (with alias entry and duplicate-name handling) or fill the field
+ * from existing vault entries. When saving, the composable prompts for an alias and, if the alias already exists
+ * (case-insensitive), requests confirmation to overwrite.
+ *
+ * @param value The current text shown in the input.
+ * @param onValueChange Callback invoked when the input text changes.
+ * @param onSaveRequested Callback invoked to persist a key under the provided alias.
+ * @param vaultEntries List of vault entries displayed in the vault dropdown; entries supply alias, strengthScore, and strengthLabel.
+ * @param onEntrySelected Callback invoked when a vault entry is chosen; the selected entry should be applied by the caller.
+ * @param modifier Modifier applied to the root composable.
+ * @param forceDropdownExpanded When true, forces the vault dropdown to open (useful for guided flows or testing).
+ */
 @Composable
 fun SecurePasswordInput(
     value: String,

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/components/SecurePasswordInput.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/components/SecurePasswordInput.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -41,7 +42,10 @@ fun SecurePasswordInput(
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
     var showMenu by remember { mutableStateOf(false) }
+
+    // Dialog States
     var showNameDialog by remember { mutableStateOf(false) }
+    var showOverwriteDialog by remember { mutableStateOf(false) }
     var newKeyName by remember { mutableStateOf("") }
 
     val haptic = LocalHapticFeedback.current
@@ -201,7 +205,7 @@ fun SecurePasswordInput(
                         value = newKeyName,
                         onValueChange = { newKeyName = it },
                         singleLine = true,
-                        placeholder = { Text("e.g. Master Key 2026") },
+                        placeholder = { Text("Enter a unique name...") },
                         shape = RoundedCornerShape(12.dp),
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -211,15 +215,48 @@ fun SecurePasswordInput(
                 Button(
                     onClick = {
                         if (newKeyName.isNotBlank()) {
-                            onSaveRequested(newKeyName)
-                            showNameDialog = false
-                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            // CHECK FOR DUPLICATES
+                            val exists = vaultEntries.any { it.alias.equals(newKeyName, ignoreCase = true) }
+                            if (exists) {
+                                showNameDialog = false
+                                showOverwriteDialog = true
+                            } else {
+                                onSaveRequested(newKeyName)
+                                showNameDialog = false
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            }
                         }
                     }
                 ) { Text("Save") }
             },
             dismissButton = {
                 TextButton(onClick = { showNameDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    // OVERWRITE WARNING DIALOG
+    if (showOverwriteDialog) {
+        AlertDialog(
+            onDismissRequest = { showOverwriteDialog = false },
+            icon = { Icon(Icons.Default.Warning, null, tint = MaterialTheme.colorScheme.error) },
+            title = { Text("Key Exists") },
+            text = { Text("A key named '$newKeyName' already exists in the Vault.\n\nDo you want to overwrite it?") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        onSaveRequested(newKeyName)
+                        showOverwriteDialog = false
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Overwrite") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showOverwriteDialog = false
+                    showNameDialog = true
+                }) { Text("Change Name") }
             }
         )
     }

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
@@ -62,6 +62,18 @@ import dev.animeshvarma.sigil.ui.theme.AnimationConfig
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
+/**
+ * Composable screen for configuring a custom cipher cascade, entering input and password, performing encrypt/decrypt actions,
+ * and managing save/overwrite profile flows.
+ *
+ * The UI exposes controls for toggling compression, reordering/removing encryption layers, adding layers via a bottom sheet,
+ * editing input and password (with vault integration), triggering encryption/decryption, and viewing/sharing/copying output.
+ * It also presents a Save Profile dialog (including optional KDF override and raw mode) and an overwrite confirmation dialog
+ * when a profile name already exists.
+ *
+ * @param viewModel The SigilViewModel providing state, actions, and persistence APIs used by the screen.
+ * @param uiState Current UiState containing layers, input/password/output text, compression flag, and editing profile id.
+ */
 @Suppress("AssignedValueIsNeverRead")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -415,6 +427,20 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
     }
 }
 
+/**
+ * Dialog that collects profile metadata and optional overrides used to save an encryption profile.
+ *
+ * Displays fields for profile name and description, an optional Raw Mode toggle (shown when `layerCount == 1`),
+ * and an optional custom KDF section initialized from `initialKdf`. The Save button is enabled only when a
+ * non-blank profile name is entered.
+ *
+ * @param initialKdf The initial KDF configuration used to prefill the custom KDF controls.
+ * @param layerCount Number of layers in the current profile; controls whether the Raw Mode option is shown.
+ * @param onDismiss Callback invoked when the user cancels or dismisses the dialog.
+ * @param onSave Callback invoked when the user confirms the save. Receives the profile name, short description,
+ *               an optional `CryptoEngine.KdfConfig` (null when KDF override is not used), and a Boolean indicating
+ *               whether Raw Mode is enabled.
+ */
 @Composable
 fun SaveProfileDialog(
     initialKdf: CryptoEngine.KdfConfig,

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
@@ -173,10 +173,9 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
                 ) {
                     itemsIndexed(
                         items = uiState.customLayers,
-                        key = { _, entry -> entry.id } // Stable ID for animation
+                        key = { _, entry -> entry.id }
                     ) { index, entry ->
 
-                        // Pop Animation Logic
                         val scale = remember { Animatable(1f) }
                         val elevation = remember { Animatable(0f) }
                         val scope = rememberCoroutineScope()
@@ -348,14 +347,16 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
     if (showSaveProfileDialog) {
         SaveProfileDialog(
             initialKdf = viewModel.getPrefs().let { CryptoEngine.KdfConfig(it.kdfIterations, it.kdfMemoryPow2, it.kdfParallelism) },
+            layerCount = uiState.customLayers.size,
             onDismiss = { showSaveProfileDialog = false },
-            onSave = { name, desc, kdfOverride ->
+            onSave = { name, desc, kdfOverride, isRaw ->
                 viewModel.saveProfile(
                     name = name,
                     description = desc,
                     layers = uiState.customLayers.map { it.algorithm },
                     kdfOverride = kdfOverride,
                     compress = uiState.isCompressionEnabled,
+                    isRaw = isRaw,
                     onSuccess = {
                         showSaveProfileDialog = false
                         viewModel.onModeSelected(SigilMode.AUTO)
@@ -371,39 +372,27 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
 
     // UPDATE CONFIRMATION DIALOG
     showOverwriteDialog?.let { existing ->
-        // Calculate Diff for UI
-        val newLayers = uiState.customLayers.map { it.algorithm.name }
-        val oldLayers = existing.layers.map { it.name }
-        val layerDiff = if (newLayers != oldLayers) "Layers changed." else "Layers unchanged."
-        val compressDiff = if (uiState.isCompressionEnabled != existing.isCompressionEnabled) "Compression setting changed." else ""
 
         AlertDialog(
             onDismissRequest = { showOverwriteDialog = null },
-            icon = { Icon(Icons.Default.Edit, null, tint = MaterialTheme.colorScheme.primary) },
-            title = { Text("Update Profile?") },
-            text = {
-                Column {
-                    Text("Update '${existing.name}' with current configuration?")
-                    Spacer(Modifier.height(8.dp))
-                    Text("Changes:", fontWeight = FontWeight.Bold)
-                    Text("• $layerDiff")
-                    if (compressDiff.isNotEmpty()) Text("• $compressDiff")
-                }
-            },
+            icon = { Icon(Icons.Default.Warning, null, tint = MaterialTheme.colorScheme.error) },
+            title = { Text("Profile Exists") },
+            text = { Text("A profile named '${existing.name}' already exists. Do you want to overwrite it?") },
             confirmButton = {
                 Button(
                     onClick = {
-                        // Create updated profile reusing ID and Name, but taking new Layers/Compression
                         val updated = existing.copy(
+                            description = "Updated via Custom Mode",
                             layers = uiState.customLayers.map { it.algorithm },
-                            isCompressionEnabled = uiState.isCompressionEnabled
-                            // Note: KDF and Description preserved from original as we don't have UI to edit them in "Quick Update"
+                            isCompressionEnabled = uiState.isCompressionEnabled,
+                            // Preserve existing raw/kdf flags if overwriting via quick-update
                         )
                         viewModel.overwriteProfile(updated)
                         showOverwriteDialog = null
                         viewModel.onModeSelected(SigilMode.AUTO)
-                    }
-                ) { Text("Update") }
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Overwrite") }
             },
             dismissButton = {
                 TextButton(onClick = { showOverwriteDialog = null }) { Text("Cancel") }
@@ -415,8 +404,9 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
 @Composable
 fun SaveProfileDialog(
     initialKdf: CryptoEngine.KdfConfig,
+    layerCount: Int,
     onDismiss: () -> Unit,
-    onSave: (String, String, CryptoEngine.KdfConfig?) -> Unit
+    onSave: (String, String, CryptoEngine.KdfConfig?, Boolean) -> Unit
 ) {
     var name by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
@@ -426,6 +416,9 @@ fun SaveProfileDialog(
     var kdfIter by remember { mutableFloatStateOf(initialKdf.iterations.toFloat()) }
     var kdfMem by remember { mutableFloatStateOf(initialKdf.memoryPow2.toFloat()) }
     var kdfPar by remember { mutableFloatStateOf(initialKdf.parallelism.toFloat()) }
+
+    // Raw Mode State
+    var useRawMode by remember { mutableStateOf(false) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -447,6 +440,31 @@ fun SaveProfileDialog(
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth()
                 )
+
+                // RAW MODE TOGGLE (Only if 1 layer)
+                if (layerCount == 1) {
+                    Spacer(Modifier.height(16.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(if (useRawMode) MaterialTheme.colorScheme.primaryContainer else Color.Transparent)
+                            .clickable { useRawMode = !useRawMode }
+                            .padding(4.dp)
+                    ) {
+                        Checkbox(checked = useRawMode, onCheckedChange = { useRawMode = it })
+                        Column {
+                            Text("Raw Mode", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                            Text(
+                                "Raw output only. No metadata.\n" +
+                                        "Auto-decrypt unsupported; requires manual profile selection.",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                }
+
                 Spacer(Modifier.height(16.dp))
 
                 // Custom KDF Toggle
@@ -484,7 +502,7 @@ fun SaveProfileDialog(
                     val kdfConfig = if (useCustomKdf) {
                         CryptoEngine.KdfConfig(kdfIter.toInt(), kdfMem.toInt(), kdfPar.toInt())
                     } else null
-                    onSave(name, description, kdfConfig)
+                    onSave(name, description, kdfConfig, useRawMode)
                 },
                 enabled = name.isNotBlank()
             ) { Text("Save") }

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
@@ -1,6 +1,7 @@
 package dev.animeshvarma.sigil.ui.screens
 
 import android.content.Intent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -16,8 +17,10 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.*
@@ -46,6 +49,8 @@ import androidx.compose.ui.zIndex
 import dev.animeshvarma.sigil.SigilViewModel
 import dev.animeshvarma.sigil.crypto.CryptoEngine
 import dev.animeshvarma.sigil.model.AlgorithmRegistry
+import dev.animeshvarma.sigil.model.EncryptionProfile
+import dev.animeshvarma.sigil.model.SigilMode
 import dev.animeshvarma.sigil.model.UiState
 import dev.animeshvarma.sigil.ui.components.SecurePasswordInput
 import dev.animeshvarma.sigil.ui.components.SigilButtonGroup
@@ -60,6 +65,9 @@ import kotlinx.coroutines.launch
 fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
     val context = LocalContext.current
     var showAddLayerSheet by remember { mutableStateOf(false) }
+    var showSaveProfileDialog by remember { mutableStateOf(false) }
+    var showOverwriteDialog by remember { mutableStateOf<EncryptionProfile?>(null) }
+
     val listState = rememberLazyListState()
     val vaultEntries by viewModel.vaultEntries.collectAsState()
 
@@ -105,14 +113,43 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text("Cipher Cascade", fontSize = 12.sp, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                SmallFloatingActionButton(
-                    onClick = { showAddLayerSheet = true },
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    contentColor = MaterialTheme.colorScheme.primary,
-                    elevation = FloatingActionButtonDefaults.elevation(0.dp),
-                    modifier = Modifier.size(32.dp)
-                ) {
-                    Icon(Icons.Default.Add, "Add Layer", modifier = Modifier.size(18.dp))
+
+                Row {
+                    // SAVE PROFILE BUTTON
+                    SmallFloatingActionButton(
+                        onClick = {
+                            if (uiState.editingProfileId != null) {
+                                val original = viewModel.getProfileById(uiState.editingProfileId)
+                                if (original != null) {
+                                    showOverwriteDialog = original
+                                } else {
+                                    showSaveProfileDialog = true
+                                }
+                            } else {
+                                showSaveProfileDialog = true
+                            }
+                        },
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                        elevation = FloatingActionButtonDefaults.elevation(0.dp),
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        val icon = if (uiState.editingProfileId != null) Icons.Default.Edit else Icons.Default.Save
+                        Icon(icon, "Save Profile", modifier = Modifier.size(16.dp))
+                    }
+
+                    Spacer(Modifier.width(8.dp))
+
+                    // ADD LAYER BUTTON
+                    SmallFloatingActionButton(
+                        onClick = { showAddLayerSheet = true },
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        contentColor = MaterialTheme.colorScheme.primary,
+                        elevation = FloatingActionButtonDefaults.elevation(0.dp),
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(Icons.Default.Add, "Add Layer", modifier = Modifier.size(18.dp))
+                    }
                 }
             }
 
@@ -306,6 +343,156 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
             )
         }
     }
+
+    // --- DIALOGS ---
+    if (showSaveProfileDialog) {
+        SaveProfileDialog(
+            initialKdf = viewModel.getPrefs().let { CryptoEngine.KdfConfig(it.kdfIterations, it.kdfMemoryPow2, it.kdfParallelism) },
+            onDismiss = { showSaveProfileDialog = false },
+            onSave = { name, desc, kdfOverride ->
+                viewModel.saveProfile(
+                    name = name,
+                    description = desc,
+                    layers = uiState.customLayers.map { it.algorithm },
+                    kdfOverride = kdfOverride,
+                    compress = uiState.isCompressionEnabled,
+                    onSuccess = {
+                        showSaveProfileDialog = false
+                        viewModel.onModeSelected(SigilMode.AUTO)
+                    },
+                    onDuplicateName = { existing ->
+                        showSaveProfileDialog = false
+                        showOverwriteDialog = existing
+                    }
+                )
+            }
+        )
+    }
+
+    // UPDATE CONFIRMATION DIALOG
+    showOverwriteDialog?.let { existing ->
+        // Calculate Diff for UI
+        val newLayers = uiState.customLayers.map { it.algorithm.name }
+        val oldLayers = existing.layers.map { it.name }
+        val layerDiff = if (newLayers != oldLayers) "Layers changed." else "Layers unchanged."
+        val compressDiff = if (uiState.isCompressionEnabled != existing.isCompressionEnabled) "Compression setting changed." else ""
+
+        AlertDialog(
+            onDismissRequest = { showOverwriteDialog = null },
+            icon = { Icon(Icons.Default.Edit, null, tint = MaterialTheme.colorScheme.primary) },
+            title = { Text("Update Profile?") },
+            text = {
+                Column {
+                    Text("Update '${existing.name}' with current configuration?")
+                    Spacer(Modifier.height(8.dp))
+                    Text("Changes:", fontWeight = FontWeight.Bold)
+                    Text("• $layerDiff")
+                    if (compressDiff.isNotEmpty()) Text("• $compressDiff")
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        // Create updated profile reusing ID and Name, but taking new Layers/Compression
+                        val updated = existing.copy(
+                            layers = uiState.customLayers.map { it.algorithm },
+                            isCompressionEnabled = uiState.isCompressionEnabled
+                            // Note: KDF and Description preserved from original as we don't have UI to edit them in "Quick Update"
+                        )
+                        viewModel.overwriteProfile(updated)
+                        showOverwriteDialog = null
+                        viewModel.onModeSelected(SigilMode.AUTO)
+                    }
+                ) { Text("Update") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showOverwriteDialog = null }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Composable
+fun SaveProfileDialog(
+    initialKdf: CryptoEngine.KdfConfig,
+    onDismiss: () -> Unit,
+    onSave: (String, String, CryptoEngine.KdfConfig?) -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+
+    // KDF Override State
+    var useCustomKdf by remember { mutableStateOf(false) }
+    var kdfIter by remember { mutableFloatStateOf(initialKdf.iterations.toFloat()) }
+    var kdfMem by remember { mutableFloatStateOf(initialKdf.memoryPow2.toFloat()) }
+    var kdfPar by remember { mutableFloatStateOf(initialKdf.parallelism.toFloat()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Save Profile") },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { if (it.length <= 20) name = it },
+                    label = { Text("Profile Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { if (it.length <= 50) description = it },
+                    label = { Text("Short Description") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(16.dp))
+
+                // Custom KDF Toggle
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth().clickable { useCustomKdf = !useCustomKdf }
+                ) {
+                    Checkbox(checked = useCustomKdf, onCheckedChange = { useCustomKdf = it })
+                    Text("Override Key Derivation (KDF)", style = MaterialTheme.typography.bodyMedium)
+                }
+
+                AnimatedVisibility(visible = useCustomKdf) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp)
+                            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha=0.3f), RoundedCornerShape(8.dp))
+                            .padding(8.dp)
+                    ) {
+                        Text("Iterations: ${kdfIter.toInt()}", style = MaterialTheme.typography.labelSmall)
+                        Slider(value = kdfIter, onValueChange = { kdfIter = it }, valueRange = 1f..32f)
+
+                        Text("Memory: ${(1 shl kdfMem.toInt())/1024} MB", style = MaterialTheme.typography.labelSmall)
+                        Slider(value = kdfMem, onValueChange = { kdfMem = it }, valueRange = 12f..18f)
+
+                        Text("Parallelism: ${kdfPar.toInt()}", style = MaterialTheme.typography.labelSmall)
+                        Slider(value = kdfPar, onValueChange = { kdfPar = it }, valueRange = 1f..8f)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    val kdfConfig = if (useCustomKdf) {
+                        CryptoEngine.KdfConfig(kdfIter.toInt(), kdfMem.toInt(), kdfPar.toInt())
+                    } else null
+                    onSave(name, description, kdfConfig)
+                },
+                enabled = name.isNotBlank()
+            ) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
 }
 
 // Movable Layer Row

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import dev.animeshvarma.sigil.SigilViewModel
 import dev.animeshvarma.sigil.crypto.CryptoEngine
 import dev.animeshvarma.sigil.model.AlgorithmRegistry
@@ -67,7 +69,18 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
     var showAddLayerSheet by remember { mutableStateOf(false) }
     var showSaveProfileDialog by remember { mutableStateOf(false) }
     var showOverwriteDialog by remember { mutableStateOf<EncryptionProfile?>(null) }
-
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_PAUSE) {
+                showAddLayerSheet = false
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
     val listState = rememberLazyListState()
     val vaultEntries by viewModel.vaultEntries.collectAsState()
 

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -454,7 +455,7 @@ fun SaveProfileDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
 
-                // RAW MODE TOGGLE (Only if 1 layer)
+                // RAW MODE TOGGLE
                 if (layerCount == 1) {
                     Spacer(Modifier.height(16.dp))
                     Row(
@@ -480,31 +481,58 @@ fun SaveProfileDialog(
 
                 Spacer(Modifier.height(16.dp))
 
-                // Custom KDF Toggle
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth().clickable { useCustomKdf = !useCustomKdf }
+                // --- CUSTOM KDF SECTION ---
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            color = if (useCustomKdf) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        .clickable { useCustomKdf = !useCustomKdf }
+                        .padding(vertical = 4.dp)
                 ) {
-                    Checkbox(checked = useCustomKdf, onCheckedChange = { useCustomKdf = it })
-                    Text("Override Key Derivation (KDF)", style = MaterialTheme.typography.bodyMedium)
-                }
-
-                AnimatedVisibility(visible = useCustomKdf) {
-                    Column(
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 8.dp)
-                            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha=0.3f), RoundedCornerShape(8.dp))
-                            .padding(8.dp)
+                            .padding(horizontal = 4.dp)
                     ) {
-                        Text("Iterations: ${kdfIter.toInt()}", style = MaterialTheme.typography.labelSmall)
-                        Slider(value = kdfIter, onValueChange = { kdfIter = it }, valueRange = 1f..32f)
+                        Checkbox(checked = useCustomKdf, onCheckedChange = { useCustomKdf = it })
+                        Column {
+                            Text(
+                                "Override Key Derivation (KDF)",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                "Fine-tune trade-offs.\n" +
+                                        "Auto-decrypt unsupported; requires manual config match.",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
 
-                        Text("Memory: ${(1 shl kdfMem.toInt())/1024} MB", style = MaterialTheme.typography.labelSmall)
-                        Slider(value = kdfMem, onValueChange = { kdfMem = it }, valueRange = 12f..18f)
+                    AnimatedVisibility(visible = useCustomKdf) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 20.dp, end = 20.dp, bottom = 12.dp)
+                        ) {
+                            HorizontalDivider(
+                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f),
+                                modifier = Modifier.padding(vertical = 8.dp)
+                            )
 
-                        Text("Parallelism: ${kdfPar.toInt()}", style = MaterialTheme.typography.labelSmall)
-                        Slider(value = kdfPar, onValueChange = { kdfPar = it }, valueRange = 1f..8f)
+                            Text("Iterations: ${kdfIter.toInt()}", style = MaterialTheme.typography.labelSmall)
+                            Slider(value = kdfIter, onValueChange = { kdfIter = it }, valueRange = 1f..32f)
+
+                            Text("Memory: ${(1 shl kdfMem.toInt()) / 1024} MB", style = MaterialTheme.typography.labelSmall)
+                            Slider(value = kdfMem, onValueChange = { kdfMem = it }, valueRange = 12f..18f)
+
+                            Text("Parallelism: ${kdfPar.toInt()}", style = MaterialTheme.typography.labelSmall)
+                            Slider(value = kdfPar, onValueChange = { kdfPar = it }, valueRange = 1f..8f)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/CustomEncryptionScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollFactory
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -82,11 +83,19 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
     var showAddLayerSheet by remember { mutableStateOf(false) }
     var showSaveProfileDialog by remember { mutableStateOf(false) }
     var showOverwriteDialog by remember { mutableStateOf<EncryptionProfile?>(null) }
+
+    // Safety warnings for Raw Mode
+    var showRawSecurityWarning by remember { mutableStateOf(false) }
+    var pendingSaveData by remember { mutableStateOf<PendingProfileData?>(null) }
+
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_PAUSE) {
                 showAddLayerSheet = false
+                showSaveProfileDialog = false
+                showOverwriteDialog = null
+                showRawSecurityWarning = false
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -103,6 +112,11 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
     val spaceInputToPass = 10.dp
     val spacePassToButtons = 17.dp
     val spaceButtonsToOutput = 8.dp
+
+    // Retrieve currently edited profile (if any) to preserve its KDF/Raw settings
+    val editingProfile = remember(uiState.editingProfileId) {
+        uiState.editingProfileId?.let { viewModel.getProfileById(it) }
+    }
 
     Column(modifier = Modifier.fillMaxHeight()) {
         Spacer(modifier = Modifier.height(7.dp))
@@ -144,16 +158,8 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
                     // SAVE PROFILE BUTTON
                     SmallFloatingActionButton(
                         onClick = {
-                            if (uiState.editingProfileId != null) {
-                                val original = viewModel.getProfileById(uiState.editingProfileId)
-                                if (original != null) {
-                                    showOverwriteDialog = original
-                                } else {
-                                    showSaveProfileDialog = true
-                                }
-                            } else {
-                                showSaveProfileDialog = true
-                            }
+                            // Always open the dialog to allow editing settings (Name, KDF, Raw)
+                            showSaveProfileDialog = true
                         },
                         containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                         contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
@@ -371,27 +377,134 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
 
     // --- DIALOGS ---
     if (showSaveProfileDialog) {
+        // Prepare initial state from editing profile or defaults
+        val defaultKdf = viewModel.getPrefs().let { CryptoEngine.KdfConfig(it.kdfIterations, it.kdfMemoryPow2, it.kdfParallelism) }
+        val initialName = editingProfile?.name ?: ""
+        val initialDesc = editingProfile?.description ?: ""
+        val initialKdfOverride = editingProfile?.kdfConfig
+        val initialIsRaw = editingProfile?.isRaw ?: false
+
         SaveProfileDialog(
-            initialKdf = viewModel.getPrefs().let { CryptoEngine.KdfConfig(it.kdfIterations, it.kdfMemoryPow2, it.kdfParallelism) },
+            initialName = initialName,
+            initialDescription = initialDesc,
+            initialKdfOverride = initialKdfOverride,
+            defaultKdf = defaultKdf,
+            initialIsRaw = initialIsRaw,
             layerCount = uiState.customLayers.size,
             onDismiss = { showSaveProfileDialog = false },
             onSave = { name, desc, kdfOverride, isRaw ->
-                viewModel.saveProfile(
-                    name = name,
-                    description = desc,
-                    layers = uiState.customLayers.map { it.algorithm },
-                    kdfOverride = kdfOverride,
-                    compress = uiState.isCompressionEnabled,
-                    isRaw = isRaw,
-                    onSuccess = {
-                        showSaveProfileDialog = false
-                        viewModel.onModeSelected(SigilMode.AUTO)
-                    },
-                    onDuplicateName = { existing ->
-                        showSaveProfileDialog = false
-                        showOverwriteDialog = existing
+                // Check if Raw Mode is unsafe (no integrity/MAC)
+                val currentAlgo = uiState.customLayers.firstOrNull()?.algorithm
+                val isUnsafeRaw = isRaw &&
+                        uiState.customLayers.size == 1 &&
+                        currentAlgo != null &&
+                        !CryptoEngine.isAEAD(currentAlgo)
+
+                val performSave = {
+                    if (editingProfile != null) {
+                        viewModel.updateExistingProfile(
+                            id = editingProfile.id,
+                            name = name,
+                            description = desc,
+                            layers = uiState.customLayers.map { it.algorithm },
+                            kdfOverride = kdfOverride,
+                            compress = uiState.isCompressionEnabled,
+                            isRaw = isRaw,
+                            onSuccess = {
+                                showSaveProfileDialog = false
+                                viewModel.onModeSelected(SigilMode.AUTO)
+                            }
+                        )
+                    } else {
+                        viewModel.saveProfile(
+                            name = name,
+                            description = desc,
+                            layers = uiState.customLayers.map { it.algorithm },
+                            kdfOverride = kdfOverride,
+                            compress = uiState.isCompressionEnabled,
+                            isRaw = isRaw,
+                            onSuccess = {
+                                showSaveProfileDialog = false
+                                viewModel.onModeSelected(SigilMode.AUTO)
+                            },
+                            onDuplicateName = { existing ->
+                                showSaveProfileDialog = false
+                                showOverwriteDialog = existing
+                            }
+                        )
                     }
+                }
+
+                if (isUnsafeRaw) {
+                    pendingSaveData = PendingProfileData(name, desc, kdfOverride, true)
+                    showRawSecurityWarning = true
+                    showSaveProfileDialog = false
+                } else {
+                    performSave()
+                }
+            }
+        )
+    }
+
+    if (showRawSecurityWarning) {
+        val algoName = uiState.customLayers.firstOrNull()?.algorithm?.name ?: "Unknown"
+        AlertDialog(
+            onDismissRequest = { showRawSecurityWarning = false },
+            icon = { Icon(Icons.Default.Security, null, tint = MaterialTheme.colorScheme.error) },
+            title = { Text("Security Warning") },
+            text = {
+                Text(
+                    "Raw Mode with $algoName lacks integrity checks (No MAC).\n\n" +
+                            "Tampering with data will not be detected. \n\n" +
+                            "Do you want to proceed anyway or return to use the standard chain?"
                 )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        // Proceed anyway
+                        pendingSaveData?.let { data ->
+                            if (editingProfile != null) {
+                                viewModel.updateExistingProfile(
+                                    id = editingProfile.id,
+                                    name = data.name,
+                                    description = data.desc,
+                                    layers = uiState.customLayers.map { it.algorithm },
+                                    kdfOverride = data.kdf,
+                                    compress = uiState.isCompressionEnabled,
+                                    isRaw = data.isRaw,
+                                    onSuccess = {
+                                        viewModel.onModeSelected(SigilMode.AUTO)
+                                    }
+                                )
+                            } else {
+                                viewModel.saveProfile(
+                                    name = data.name,
+                                    description = data.desc,
+                                    layers = uiState.customLayers.map { it.algorithm },
+                                    kdfOverride = data.kdf,
+                                    compress = uiState.isCompressionEnabled,
+                                    isRaw = true,
+                                    onSuccess = {
+                                        viewModel.onModeSelected(SigilMode.AUTO)
+                                    },
+                                    onDuplicateName = { existing ->
+                                        showOverwriteDialog = existing
+                                    }
+                                )
+                            }
+                        }
+                        showRawSecurityWarning = false
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Proceed (Unsafe)") }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showRawSecurityWarning = false
+                    }
+                ) { Text("Cancel") }
             }
         )
     }
@@ -427,6 +540,14 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
     }
 }
 
+// Data holder for pending save
+private data class PendingProfileData(
+    val name: String,
+    val desc: String,
+    val kdf: CryptoEngine.KdfConfig?,
+    val isRaw: Boolean
+)
+
 /**
  * Dialog that collects profile metadata and optional overrides used to save an encryption profile.
  *
@@ -434,7 +555,11 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
  * and an optional custom KDF section initialized from `initialKdf`. The Save button is enabled only when a
  * non-blank profile name is entered.
  *
- * @param initialKdf The initial KDF configuration used to prefill the custom KDF controls.
+ * @param initialName The starting name for the profile (e.g. when editing).
+ * @param initialDescription The starting description for the profile.
+ * @param initialKdfOverride The existing KDF override if any, to prefill the toggle and sliders.
+ * @param defaultKdf The default/global KDF config to fallback to if no override is set.
+ * @param initialIsRaw The starting raw mode state.
  * @param layerCount Number of layers in the current profile; controls whether the Raw Mode option is shown.
  * @param onDismiss Callback invoked when the user cancels or dismisses the dialog.
  * @param onSave Callback invoked when the user confirms the save. Receives the profile name, short description,
@@ -443,26 +568,32 @@ fun CustomEncryptionScreen(viewModel: SigilViewModel, uiState: UiState) {
  */
 @Composable
 fun SaveProfileDialog(
-    initialKdf: CryptoEngine.KdfConfig,
+    initialName: String = "",
+    initialDescription: String = "",
+    initialKdfOverride: CryptoEngine.KdfConfig?,
+    defaultKdf: CryptoEngine.KdfConfig,
+    initialIsRaw: Boolean = false,
     layerCount: Int,
     onDismiss: () -> Unit,
     onSave: (String, String, CryptoEngine.KdfConfig?, Boolean) -> Unit
 ) {
-    var name by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf(initialName) }
+    var description by remember { mutableStateOf(initialDescription) }
 
     // KDF Override State
-    var useCustomKdf by remember { mutableStateOf(false) }
-    var kdfIter by remember { mutableFloatStateOf(initialKdf.iterations.toFloat()) }
-    var kdfMem by remember { mutableFloatStateOf(initialKdf.memoryPow2.toFloat()) }
-    var kdfPar by remember { mutableFloatStateOf(initialKdf.parallelism.toFloat()) }
+    var useCustomKdf by remember { mutableStateOf(initialKdfOverride != null) }
+    val effectiveKdf = initialKdfOverride ?: defaultKdf
+
+    var kdfIter by remember { mutableFloatStateOf(effectiveKdf.iterations.toFloat()) }
+    var kdfMem by remember { mutableFloatStateOf(effectiveKdf.memoryPow2.toFloat()) }
+    var kdfPar by remember { mutableFloatStateOf(effectiveKdf.parallelism.toFloat()) }
 
     // Raw Mode State
-    var useRawMode by remember { mutableStateOf(false) }
+    var useRawMode by remember { mutableStateOf(initialIsRaw) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Save Profile") },
+        title = { Text(if (initialName.isEmpty()) "Save Profile" else "Edit Profile") },
         text = {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 OutlinedTextField(
@@ -571,7 +702,7 @@ fun SaveProfileDialog(
                     } else null
                     onSave(name, description, kdfConfig, useRawMode)
                 },
-                enabled = name.isNotBlank()
+                enabled = name.isNotBlank() && layerCount > 0
             ) { Text("Save") }
         },
         dismissButton = {
@@ -622,6 +753,7 @@ fun MovableLayerItem(
 }
 
 // Add Layer Sheet
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AddLayerSheetContent(onAdd: (List<CryptoEngine.Algorithm>) -> Unit) {
     var searchQuery by remember { mutableStateOf("") }
@@ -630,9 +762,21 @@ fun AddLayerSheetContent(onAdd: (List<CryptoEngine.Algorithm>) -> Unit) {
     val allAlgos = AlgorithmRegistry.supportedAlgorithms
     val focusManager = LocalFocusManager.current
 
-    Column(modifier = Modifier.padding(16.dp)) {
+    val filteredAlgos = remember(searchQuery, searchDescription, allAlgos) {
+        allAlgos.filter { algo ->
+            val nameMatch = algo.name.contains(searchQuery, ignoreCase = true)
+            if (searchDescription) nameMatch || algo.description.contains(searchQuery, ignoreCase = true) else nameMatch
+        }
+    }
+
+    Column(modifier = Modifier.padding(top = 16.dp)) {
+
+        // Header
         Row(
-            modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -652,27 +796,31 @@ fun AddLayerSheetContent(onAdd: (List<CryptoEngine.Algorithm>) -> Unit) {
                     .height(32.dp)
                     .scale(scale)
             ) {
-                Text(
-                    text = "Add${if (selectedAlgos.isNotEmpty()) " (${selectedAlgos.size})" else ""}",
-                    fontSize = 13.sp
-                )
+                Text(text = "Add${if (selectedAlgos.isNotEmpty()) " (${selectedAlgos.size})" else ""}", fontSize = 13.sp)
             }
         }
 
-        OutlinedTextField(
-            value = searchQuery,
-            onValueChange = { searchQuery = it },
-            placeholder = { Text("Search (e.g. AES, Serpent)...") },
-            leadingIcon = { Icon(Icons.Default.Search, null) },
-            trailingIcon = { IconButton(onClick = { focusManager.clearFocus() }) { Icon(Icons.AutoMirrored.Filled.ArrowForward, "Done") } },
-            modifier = Modifier.fillMaxWidth(),
-            shape = CircleShape,
-            singleLine = true
-        )
+        // Search Bar
+        Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = { Text("Search (e.g. AES, Serpent)...") },
+                leadingIcon = { Icon(Icons.Default.Search, null) },
+                trailingIcon = { IconButton(onClick = { focusManager.clearFocus() }) { Icon(Icons.AutoMirrored.Filled.ArrowForward, "Done") } },
+                modifier = Modifier.fillMaxWidth(),
+                shape = CircleShape,
+                singleLine = true
+            )
+        }
 
+        // Toggle
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp).clickable { searchDescription = !searchDescription }
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { searchDescription = !searchDescription }
+                .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
             Switch(checked = searchDescription, onCheckedChange = { searchDescription = it }, modifier = Modifier.scale(0.7f))
             Spacer(modifier = Modifier.width(8.dp))
@@ -682,68 +830,95 @@ fun AddLayerSheetContent(onAdd: (List<CryptoEngine.Algorithm>) -> Unit) {
         Spacer(modifier = Modifier.height(8.dp))
 
         Box(modifier = Modifier.weight(1f)) {
-            LazyColumn {
-                val filtered = allAlgos.filter { algo ->
-                    val nameMatch = algo.name.contains(searchQuery, ignoreCase = true)
-                    if (searchDescription) nameMatch || algo.description.contains(searchQuery, ignoreCase = true) else nameMatch
-                }
+            CompositionLocalProvider(
+                LocalOverscrollFactory provides null
+            ) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 24.dp)
+                ) {
+                    items(
+                        items = filteredAlgos,
+                        key = { it.id }
+                    ) { algoData ->
+                        val engineEnum = CryptoEngine.Algorithm.valueOf(algoData.id)
+                        val isSelected = selectedAlgos.contains(engineEnum)
+                        val isWeak = algoData.isWeak
+                        val containerColor = when {
+                            isSelected -> MaterialTheme.colorScheme.secondaryContainer
+                            isWeak -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.1f)
+                            else -> MaterialTheme.colorScheme.surfaceContainerLow
+                        }
 
-                items(filtered) { algoData ->
-                    val engineEnum = CryptoEngine.Algorithm.valueOf(algoData.id)
-                    val isSelected = selectedAlgos.contains(engineEnum)
-
-                    // WARNING LOGIC: Flag weak ciphers
-                    val isWeak = algoData.isWeak
-                    val containerColor = when {
-                        isSelected -> MaterialTheme.colorScheme.secondaryContainer
-                        isWeak -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.1f)
-                        else -> MaterialTheme.colorScheme.surfaceContainerLow
+                        Surface(
+                            modifier = Modifier
+                                .padding(vertical = 4.dp)
+                                .fillMaxWidth(),
+                            shape = RoundedCornerShape(16.dp),
+                            color = containerColor
+                        ) {
+                            ListItem(
+                                headlineContent = {
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        Text(
+                                            algoData.name,
+                                            fontWeight = FontWeight.SemiBold,
+                                            color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
+                                        )
+                                        if (isWeak) {
+                                            Spacer(Modifier.width(8.dp))
+                                            Icon(Icons.Default.Warning, null, tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(16.dp))
+                                        }
+                                    }
+                                },
+                                supportingContent = {
+                                    Column {
+                                        Text(algoData.description)
+                                        if (isWeak) {
+                                            Text(algoData.securityWarning ?: "Weak Cipher", color = MaterialTheme.colorScheme.error, fontSize = 11.sp, fontWeight = FontWeight.Bold)
+                                        }
+                                    }
+                                },
+                                trailingContent = {
+                                    Checkbox(
+                                        checked = isSelected,
+                                        onCheckedChange = { checked ->
+                                            selectedAlgos = if (checked) selectedAlgos + engineEnum else selectedAlgos - engineEnum
+                                        }
+                                    )
+                                },
+                                modifier = Modifier.clickable {
+                                    selectedAlgos = if (isSelected) selectedAlgos - engineEnum else selectedAlgos + engineEnum
+                                },
+                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+                            )
+                        }
                     }
 
-                    Surface(
-                        modifier = Modifier.padding(vertical = 4.dp).clip(RoundedCornerShape(16.dp)),
-                        color = containerColor
-                    ) {
-                        ListItem(
-                            headlineContent = {
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Text(
-                                        algoData.name,
-                                        fontWeight = FontWeight.SemiBold,
-                                        color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
-                                    )
-                                    if (isWeak) {
-                                        Spacer(Modifier.width(8.dp))
-                                        Icon(Icons.Default.Warning, null, tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(16.dp))
-                                    }
-                                }
-                            },
-                            supportingContent = {
-                                Column {
-                                    Text(algoData.description)
-                                    if (isWeak) {
-                                        Text(algoData.securityWarning ?: "Weak Cipher", color = MaterialTheme.colorScheme.error, fontSize = 11.sp, fontWeight = FontWeight.Bold)
-                                    }
-                                }
-                            },
-                            trailingContent = {
-                                Checkbox(
-                                    checked = isSelected,
-                                    onCheckedChange = { checked ->
-                                        selectedAlgos = if (checked) selectedAlgos + engineEnum else selectedAlgos - engineEnum
-                                    }
-                                )
-                            },
-                            modifier = Modifier.clickable {
-                                selectedAlgos = if (isSelected) selectedAlgos - engineEnum else selectedAlgos + engineEnum
-                            },
-                            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                        )
+                    item {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 24.dp, bottom = 12.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            HorizontalDivider(
+                                modifier = Modifier.width(40.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "END OF LIST",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.outline,
+                                fontWeight = FontWeight.Bold,
+                                letterSpacing = 1.sp
+                            )
+                        }
                     }
                 }
             }
         }
-        Spacer(modifier = Modifier.height(24.dp))
     }
 }
 

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
@@ -1,44 +1,101 @@
+@file:Suppress("AssignedValueIsNeverRead")
+
 package dev.animeshvarma.sigil.ui.screens
 
 import android.content.Intent
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import dev.animeshvarma.sigil.SigilViewModel
+import dev.animeshvarma.sigil.crypto.CryptoEngine
+import dev.animeshvarma.sigil.model.AlgorithmRegistry
+import dev.animeshvarma.sigil.model.EncryptionProfile
+import dev.animeshvarma.sigil.model.SigilMode
 import dev.animeshvarma.sigil.model.UiState
 import dev.animeshvarma.sigil.ui.components.SecurePasswordInput
 import dev.animeshvarma.sigil.ui.components.SigilButtonGroup
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
     val context = LocalContext.current
     val vaultEntries by viewModel.vaultEntries.collectAsState()
+    var showProfileSheet by remember { mutableStateOf(false) }
+
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_PAUSE) {
+                showProfileSheet = false
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     Column(modifier = Modifier.fillMaxHeight()) {
-        // 1. Input Field
-        OutlinedTextField(
-            value = uiState.autoInput,
-            onValueChange = { viewModel.onInputTextChanged(it) },
-            label = { Text("Input Text") },
-            modifier = Modifier.weight(1f).fillMaxWidth(),
-            shape = RoundedCornerShape(24.dp),
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedContainerColor = Color.Transparent,
-                unfocusedContainerColor = Color.Transparent,
-                focusedBorderColor = MaterialTheme.colorScheme.primary,
-                unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+
+        // 1. INPUT FIELD WITH OVERLAY
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            OutlinedTextField(
+                value = uiState.autoInput,
+                onValueChange = { viewModel.onInputTextChanged(it) },
+                label = { Text("Input Text") },
+                modifier = Modifier.fillMaxSize(),
+                shape = RoundedCornerShape(24.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+                )
             )
-        )
+
+            // BOOKMARK BUTTON
+            SmallFloatingActionButton(
+                onClick = { showProfileSheet = true },
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                contentColor = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(end = 8.dp, top = 15.dp)
+                    .size(36.dp),
+                elevation = FloatingActionButtonDefaults.elevation(2.dp)
+            ) {
+                Icon(Icons.Default.Bookmarks, "Profiles", modifier = Modifier.size(20.dp))
+            }
+        }
 
         Spacer(modifier = Modifier.height(11.dp))
 
@@ -66,7 +123,7 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
 
         Spacer(modifier = Modifier.height(10.dp))
 
-        // 4. Output Field (With Share Intent & Secure Copy)
+        // 4. Output Field
         OutlinedTextField(
             value = uiState.autoOutput,
             onValueChange = { },
@@ -81,10 +138,7 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
                 unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
             ),
             trailingIcon = {
-                Column(
-                    modifier = Modifier.padding(end = 4.dp)
-                ) {
-                    // SHARE BUTTON
+                Column(modifier = Modifier.padding(end = 4.dp)) {
                     IconButton(onClick = {
                         if (uiState.autoOutput.isNotEmpty()) {
                             val sendIntent = Intent().apply {
@@ -120,4 +174,270 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
         )
         Spacer(modifier = Modifier.height(8.dp))
     }
+
+    // --- PROFILE SELECTION SHEET ---
+    if (showProfileSheet) {
+        ModalBottomSheet(onDismissRequest = { showProfileSheet = false }) {
+            Column(Modifier.padding(horizontal = 16.dp)) {
+                // Header
+                Row(
+                    Modifier.fillMaxWidth().padding(bottom = 16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column {
+                        Text("Encryption Profiles", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                        Text(
+                            "Active: ${uiState.activeProfile.name}",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+
+                    FilledTonalButton(onClick = {
+                        showProfileSheet = false
+                        viewModel.onModeSelected(SigilMode.CUSTOM)
+                        Toast.makeText(context, "Configure layers, then click Save.", Toast.LENGTH_LONG).show()
+                    }) {
+                        Icon(Icons.Default.Add, null, Modifier.size(18.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text("Create")
+                    }
+                }
+
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(bottom = 48.dp)
+                ) {
+                    items(uiState.availableProfiles) { profile ->
+                        ExpandableProfileCard(
+                            profile = profile,
+                            isActive = profile.id == uiState.activeProfile.id,
+                            onSelect = {
+                                viewModel.selectProfile(it)
+                                showProfileSheet = false
+                            },
+                            onEdit = {
+                                viewModel.loadProfileToCustomMode(it)
+                                showProfileSheet = false
+                            },
+                            onDelete = { viewModel.deleteProfile(it.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ExpandableProfileCard(
+    profile: EncryptionProfile,
+    isActive: Boolean,
+    onSelect: (EncryptionProfile) -> Unit,
+    onEdit: (EncryptionProfile) -> Unit,
+    onDelete: (EncryptionProfile) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var algoInfoDialog by remember { mutableStateOf<CryptoEngine.Algorithm?>(null) }
+
+    // Weakness Check
+    val weakCiphers = remember(profile) {
+        profile.layers.mapNotNull { algo ->
+            AlgorithmRegistry.supportedAlgorithms.find { it.id == algo.name }
+        }.filter { it.isWeak }
+    }
+    val isWeak = weakCiphers.isNotEmpty()
+
+    val borderColor = if (isActive) MaterialTheme.colorScheme.primary else Color.Transparent
+    val containerColor = if (isActive) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f) else MaterialTheme.colorScheme.surfaceContainer
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, borderColor, RoundedCornerShape(12.dp))
+            .clickable { expanded = !expanded },
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            // --- HEADER ROW (Always Visible) ---
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(profile.name, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                        if (isActive) {
+                            Spacer(Modifier.width(6.dp))
+                            Icon(Icons.Default.CheckCircle, null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
+                        }
+                    }
+
+                    Spacer(Modifier.height(4.dp))
+
+                    // Mini Badges Row
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        // Algo Count
+                        BadgeText("${profile.layers.size} Algos")
+                        Spacer(Modifier.width(6.dp))
+
+                        // Compression
+                        if (profile.isCompressionEnabled) {
+                            BadgeText("CMP", MaterialTheme.colorScheme.tertiary)
+                            Spacer(Modifier.width(6.dp))
+                        }
+
+                        // KDF
+                        if (profile.kdfConfig != null) {
+                            BadgeText("Custom KDF", MaterialTheme.colorScheme.secondary)
+                            Spacer(Modifier.width(6.dp))
+                        }
+
+                        // Weak Warning
+                        if (isWeak) {
+                            BadgeText("Weak", MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+
+                // Expand Icon
+                val rotation by animateFloatAsState(if (expanded) 180f else 0f)
+                Icon(
+                    Icons.Default.ExpandMore,
+                    null,
+                    modifier = Modifier.rotate(rotation),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // --- EXPANDED CONTENT ---
+            AnimatedVisibility(visible = expanded) {
+                Column(Modifier.padding(top = 12.dp)) {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    Spacer(Modifier.height(8.dp))
+
+                    // Description
+                    if (profile.description.isNotBlank()) {
+                        Text(
+                            profile.description,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.height(8.dp))
+                    }
+
+                    // Layer Chain Flow
+                    Text("Algorithm Chain (Tap for info):", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+                    FlowRow(
+                        modifier = Modifier.padding(top = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        profile.layers.forEachIndexed { index, algo ->
+                            SuggestionChip(
+                                onClick = { algoInfoDialog = algo },
+                                label = { Text(algo.name.replace("_", "-")) },
+                                colors = SuggestionChipDefaults.suggestionChipColors(
+                                    containerColor = MaterialTheme.colorScheme.surface
+                                ),
+                                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                                modifier = Modifier.height(24.dp)
+                            )
+
+                            if (index < profile.layers.size - 1) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .size(12.dp)
+                                        .align(Alignment.CenterVertically),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(Modifier.height(16.dp))
+
+                    // ACTIONS ROW
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        if (!profile.isBuiltIn) {
+                            OutlinedButton(
+                                onClick = { onDelete(profile) },
+                                contentPadding = PaddingValues(horizontal = 12.dp),
+                                modifier = Modifier.height(32.dp),
+                                colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                            ) {
+                                Icon(Icons.Default.Delete, null, Modifier.size(14.dp))
+                            }
+                            Spacer(Modifier.width(8.dp))
+                            OutlinedButton(
+                                onClick = { onEdit(profile) },
+                                contentPadding = PaddingValues(horizontal = 12.dp),
+                                modifier = Modifier.height(32.dp)
+                            ) {
+                                Icon(Icons.Default.Edit, null, Modifier.size(14.dp))
+                                Spacer(Modifier.width(4.dp))
+                                Text("Edit", fontSize = 12.sp)
+                            }
+                            Spacer(Modifier.width(8.dp))
+                        }
+
+                        Button(
+                            onClick = { onSelect(profile) },
+                            enabled = !isActive,
+                            contentPadding = PaddingValues(horizontal = 16.dp),
+                            modifier = Modifier.height(32.dp)
+                        ) {
+                            Text(if (isActive) "Selected" else "Use Profile", fontSize = 12.sp)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ALGO INFO DIALOG
+    algoInfoDialog?.let { algo ->
+        val details = AlgorithmRegistry.supportedAlgorithms.find { it.id == algo.name }
+        AlertDialog(
+            onDismissRequest = { algoInfoDialog = null },
+            icon = { Icon(Icons.Default.Info, null) },
+            title = { Text(details?.name ?: algo.name) },
+            text = {
+                Column {
+                    Text(details?.description ?: "No description available.")
+                    Spacer(Modifier.height(8.dp))
+                    Text("Type: ${details?.type ?: "Unknown"}", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
+                    if (details?.isWeak == true) {
+                        Text("Warning: ${details.securityWarning}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { algoInfoDialog = null }) { Text("Close") }
+            }
+        )
+    }
+}
+
+@Composable
+fun BadgeText(text: String, color: Color = MaterialTheme.colorScheme.primary) {
+    Text(
+        text,
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Bold,
+        color = color,
+        modifier = Modifier
+            .background(color.copy(alpha = 0.1f), RoundedCornerShape(4.dp))
+            .padding(horizontal = 4.dp, vertical = 2.dp)
+    )
 }

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
@@ -57,6 +57,16 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
     val vaultEntries by viewModel.vaultEntries.collectAsState()
     var showProfileSheet by remember { mutableStateOf(false) }
 
+    // --- TOAST HELPER ---
+    val currentToast = remember { mutableStateOf<Toast?>(null) }
+
+    val showToast: (String) -> Unit = { message ->
+        currentToast.value?.cancel()
+        val toast = Toast.makeText(context, message, Toast.LENGTH_SHORT)
+        currentToast.value = toast
+        toast.show()
+    }
+
     // Lifecycle safety for sheet
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
@@ -164,7 +174,6 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
                     IconButton(onClick = {
                         if (uiState.autoOutput.isNotEmpty()) {
                             viewModel.copyToClipboardSecurely(uiState.autoOutput, "Sigil Output")
-                            Toast.makeText(context, "Copied to secure clipboard", Toast.LENGTH_SHORT).show()
                         }
                     }) {
                         Icon(
@@ -201,7 +210,7 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
                     FilledTonalButton(onClick = {
                         showProfileSheet = false
                         viewModel.onModeSelected(SigilMode.CUSTOM)
-                        Toast.makeText(context, "Switched to Custom Mode", Toast.LENGTH_SHORT).show()
+                        showToast("Switched to Custom Mode")
                     }) {
                         Icon(Icons.Default.Add, null, Modifier.size(18.dp))
                         Spacer(Modifier.width(8.dp))
@@ -225,16 +234,19 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
                             isActive = profile.id == uiState.activeProfile.id,
                             onSelect = {
                                 viewModel.selectProfile(it)
-                                Toast.makeText(context, "Activated: ${it.name}", Toast.LENGTH_SHORT).show()
+                                // UPDATED: Use helper
+                                showToast("Activated: ${it.name}")
                             },
                             onEdit = {
                                 viewModel.loadProfileToCustomMode(it)
                                 showProfileSheet = false
-                                Toast.makeText(context, "Editing ${it.name}", Toast.LENGTH_SHORT).show()
+                                // UPDATED: Use helper
+                                showToast("Editing ${it.name}")
                             },
                             onDelete = {
                                 viewModel.deleteProfile(it.id)
-                                Toast.makeText(context, "Profile deleted", Toast.LENGTH_SHORT).show()
+                                // UPDATED: Use helper
+                                showToast("Profile deleted")
                             }
                         )
                     }
@@ -298,7 +310,7 @@ fun ExpandableProfileCard(
                     // Mini Badges Row
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         if (profile.isBuiltIn) {
-                            BadgeText("Default", MaterialTheme.colorScheme.secondary)
+                            BadgeText("Built-in", MaterialTheme.colorScheme.secondary)
                             Spacer(Modifier.width(6.dp))
                         }
 
@@ -306,7 +318,7 @@ fun ExpandableProfileCard(
                         BadgeText("${profile.layers.size} Algos")
 
                         // Compression
-                        if (profile.isCompressionEnabled) {
+                        if (profile.isCompressionEnabled && !profile.isRaw) {
                             Spacer(Modifier.width(6.dp))
                             BadgeText("CMP", MaterialTheme.colorScheme.tertiary)
                         }
@@ -314,13 +326,19 @@ fun ExpandableProfileCard(
                         // KDF
                         if (profile.kdfConfig != null) {
                             Spacer(Modifier.width(6.dp))
-                            BadgeText("KDF+", MaterialTheme.colorScheme.secondary)
+                            BadgeText("KDF+", MaterialTheme.colorScheme.tertiary)
                         }
 
                         // Weak Warning
                         if (isWeak) {
                             Spacer(Modifier.width(6.dp))
                             BadgeText("Weak", MaterialTheme.colorScheme.error)
+                        }
+
+                        // Raw Badge
+                        if (profile.isRaw) {
+                            Spacer(Modifier.width(6.dp))
+                            BadgeText("RAW", MaterialTheme.colorScheme.tertiary)
                         }
                     }
                 }

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
@@ -6,7 +6,9 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -18,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
@@ -29,6 +32,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -46,19 +50,18 @@ import dev.animeshvarma.sigil.model.UiState
 import dev.animeshvarma.sigil.ui.components.SecurePasswordInput
 import dev.animeshvarma.sigil.ui.components.SigilButtonGroup
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
     val context = LocalContext.current
     val vaultEntries by viewModel.vaultEntries.collectAsState()
     var showProfileSheet by remember { mutableStateOf(false) }
 
+    // Lifecycle safety for sheet
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_PAUSE) {
-                showProfileSheet = false
-            }
+            if (event == Lifecycle.Event.ON_PAUSE) showProfileSheet = false
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
@@ -99,7 +102,7 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
 
         Spacer(modifier = Modifier.height(11.dp))
 
-        // 2. SECURE PASSWORD FIELD (Vault Integrated)
+        // 2. SECURE PASSWORD FIELD
         SecurePasswordInput(
             value = uiState.autoPassword,
             onValueChange = { viewModel.onPasswordChanged(it) },
@@ -114,7 +117,7 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
 
         Spacer(modifier = Modifier.height(18.dp))
 
-        // 3. Button Group (Logs, Encrypt, Decrypt)
+        // 3. Button Group
         SigilButtonGroup(
             onLogs = { viewModel.onLogsClicked() },
             onEncrypt = { viewModel.onEncrypt() },
@@ -161,6 +164,7 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
                     IconButton(onClick = {
                         if (uiState.autoOutput.isNotEmpty()) {
                             viewModel.copyToClipboardSecurely(uiState.autoOutput, "Sigil Output")
+                            Toast.makeText(context, "Copied to secure clipboard", Toast.LENGTH_SHORT).show()
                         }
                     }) {
                         Icon(
@@ -197,7 +201,7 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
                     FilledTonalButton(onClick = {
                         showProfileSheet = false
                         viewModel.onModeSelected(SigilMode.CUSTOM)
-                        Toast.makeText(context, "Configure layers, then click Save.", Toast.LENGTH_LONG).show()
+                        Toast.makeText(context, "Switched to Custom Mode", Toast.LENGTH_SHORT).show()
                     }) {
                         Icon(Icons.Default.Add, null, Modifier.size(18.dp))
                         Spacer(Modifier.width(8.dp))
@@ -210,19 +214,28 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(bottom = 48.dp)
                 ) {
-                    items(uiState.availableProfiles) { profile ->
+                    items(
+                        items = uiState.availableProfiles,
+                        key = { it.id }
+                    ) { profile ->
+                        Modifier.animateItem(placementSpec = tween(durationMillis = 300))
+
                         ExpandableProfileCard(
                             profile = profile,
                             isActive = profile.id == uiState.activeProfile.id,
                             onSelect = {
                                 viewModel.selectProfile(it)
-                                showProfileSheet = false
+                                Toast.makeText(context, "Activated: ${it.name}", Toast.LENGTH_SHORT).show()
                             },
                             onEdit = {
                                 viewModel.loadProfileToCustomMode(it)
                                 showProfileSheet = false
+                                Toast.makeText(context, "Editing ${it.name}", Toast.LENGTH_SHORT).show()
                             },
-                            onDelete = { viewModel.deleteProfile(it.id) }
+                            onDelete = {
+                                viewModel.deleteProfile(it.id)
+                                Toast.makeText(context, "Profile deleted", Toast.LENGTH_SHORT).show()
+                            }
                         )
                     }
                 }
@@ -258,6 +271,7 @@ fun ExpandableProfileCard(
         modifier = Modifier
             .fillMaxWidth()
             .border(1.dp, borderColor, RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(12.dp))
             .clickable { expanded = !expanded },
         colors = CardDefaults.cardColors(containerColor = containerColor),
         shape = RoundedCornerShape(12.dp)
@@ -269,6 +283,7 @@ fun ExpandableProfileCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier.fillMaxWidth()
             ) {
+                // Left Side: Name + Badges
                 Column(modifier = Modifier.weight(1f)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(profile.name, fontWeight = FontWeight.Bold, fontSize = 16.sp)
@@ -282,37 +297,77 @@ fun ExpandableProfileCard(
 
                     // Mini Badges Row
                     Row(verticalAlignment = Alignment.CenterVertically) {
+                        if (profile.isBuiltIn) {
+                            BadgeText("Default", MaterialTheme.colorScheme.secondary)
+                            Spacer(Modifier.width(6.dp))
+                        }
+
                         // Algo Count
                         BadgeText("${profile.layers.size} Algos")
-                        Spacer(Modifier.width(6.dp))
 
                         // Compression
                         if (profile.isCompressionEnabled) {
-                            BadgeText("CMP", MaterialTheme.colorScheme.tertiary)
                             Spacer(Modifier.width(6.dp))
+                            BadgeText("CMP", MaterialTheme.colorScheme.tertiary)
                         }
 
                         // KDF
                         if (profile.kdfConfig != null) {
-                            BadgeText("Custom KDF", MaterialTheme.colorScheme.secondary)
                             Spacer(Modifier.width(6.dp))
+                            BadgeText("KDF+", MaterialTheme.colorScheme.secondary)
                         }
 
                         // Weak Warning
                         if (isWeak) {
+                            Spacer(Modifier.width(6.dp))
                             BadgeText("Weak", MaterialTheme.colorScheme.error)
                         }
                     }
                 }
 
-                // Expand Icon
-                val rotation by animateFloatAsState(if (expanded) 180f else 0f)
-                Icon(
-                    Icons.Default.ExpandMore,
-                    null,
-                    modifier = Modifier.rotate(rotation),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                // Right Side: Selection Action + Expand
+                Row(verticalAlignment = Alignment.CenterVertically) {
+
+                    // SWITCHING LOGIC: Use vs Active Badge
+                    AnimatedVisibility(visible = !isActive) {
+                        OutlinedButton(
+                            onClick = { onSelect(profile) },
+                            modifier = Modifier.height(36.dp),
+                            contentPadding = PaddingValues(horizontal = 12.dp),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
+                        ) {
+                            Text("Use")
+                        }
+                    }
+
+                    AnimatedVisibility(visible = isActive) {
+                        // Badge style button for Active state
+                        Button(
+                            onClick = {},
+                            enabled = false,
+                            modifier = Modifier.height(36.dp),
+                            contentPadding = PaddingValues(horizontal = 12.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                disabledContainerColor = MaterialTheme.colorScheme.primary,
+                                disabledContentColor = MaterialTheme.colorScheme.onPrimary
+                            )
+                        ) {
+                            Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp))
+                            Spacer(Modifier.width(6.dp))
+                            Text("Active")
+                        }
+                    }
+
+                    Spacer(Modifier.width(8.dp))
+
+                    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "ExpandArrow")
+                    Icon(
+                        Icons.Default.ExpandMore,
+                        null,
+                        modifier = Modifier.rotate(rotation),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
 
             // --- EXPANDED CONTENT ---
@@ -348,28 +403,18 @@ fun ExpandableProfileCard(
                                 border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
                                 modifier = Modifier.height(24.dp)
                             )
-
                             if (index < profile.layers.size - 1) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                                    contentDescription = null,
-                                    modifier = Modifier
-                                        .size(12.dp)
-                                        .align(Alignment.CenterVertically),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                                Icon(Icons.AutoMirrored.Filled.ArrowForward, null, modifier = Modifier.size(12.dp).align(Alignment.CenterVertically), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                             }
                         }
                     }
 
-                    Spacer(Modifier.height(16.dp))
-
-                    // ACTIONS ROW
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        if (!profile.isBuiltIn) {
+                    if (!profile.isBuiltIn) {
+                        Spacer(Modifier.height(16.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End
+                        ) {
                             OutlinedButton(
                                 onClick = { onDelete(profile) },
                                 contentPadding = PaddingValues(horizontal = 12.dp),
@@ -388,16 +433,6 @@ fun ExpandableProfileCard(
                                 Spacer(Modifier.width(4.dp))
                                 Text("Edit", fontSize = 12.sp)
                             }
-                            Spacer(Modifier.width(8.dp))
-                        }
-
-                        Button(
-                            onClick = { onSelect(profile) },
-                            enabled = !isActive,
-                            contentPadding = PaddingValues(horizontal = 16.dp),
-                            modifier = Modifier.height(32.dp)
-                        ) {
-                            Text(if (isActive) "Selected" else "Use Profile", fontSize = 12.sp)
                         }
                     }
                 }

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
@@ -50,6 +50,17 @@ import dev.animeshvarma.sigil.model.UiState
 import dev.animeshvarma.sigil.ui.components.SecurePasswordInput
 import dev.animeshvarma.sigil.ui.components.SigilButtonGroup
 
+/**
+ * Renders the encryption screen UI including input, secure password entry, encrypt/decrypt controls,
+ * output with share/copy actions, and a bottom sheet for selecting, creating, editing, or deleting
+ * encryption profiles.
+ *
+ * The sheet automatically closes when the lifecycle is paused. Profile actions delegate to the
+ * provided ViewModel and display short toasts for feedback.
+ *
+ * @param viewModel ViewModel that manages state and handles user actions (vault, profile management, encryption, logging, clipboard).
+ * @param uiState Current UI state used to populate fields, available profiles, and active profile information.
+ */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
@@ -256,6 +267,19 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
     }
 }
 
+/**
+ * Renders an expandable card for an encryption profile that shows name, badges, algorithm chain,
+ * active state, and provides actions to select, edit, delete, and view per-algorithm details.
+ *
+ * The card toggles between a compact header and expanded details, highlights the active profile,
+ * displays warnings for weak algorithms, and shows an algorithm info dialog when an algorithm chip is tapped.
+ *
+ * @param profile The EncryptionProfile to display.
+ * @param isActive Whether this profile is currently active; affects visual emphasis and the action shown.
+ * @param onSelect Callback invoked with the profile when the user chooses to use this profile.
+ * @param onEdit Callback invoked with the profile when the user requests to edit it.
+ * @param onDelete Callback invoked with the profile when the user requests to delete it.
+ */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ExpandableProfileCard(
@@ -482,6 +506,15 @@ fun ExpandableProfileCard(
     }
 }
 
+/**
+ * Renders a small rounded badge with bold text for status indicators.
+ *
+ * The badge uses a low-opacity background derived from [color] and applies compact padding
+ * and a 10sp bold text style.
+ *
+ * @param text The badge label to display.
+ * @param color The foreground color for the text and base for the badge background (background uses `color` at 10% alpha).
+ */
 @Composable
 fun BadgeText(text: String, color: Color = MaterialTheme.colorScheme.primary) {
     Text(

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
@@ -6,9 +6,7 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -61,7 +59,7 @@ import dev.animeshvarma.sigil.ui.components.SigilButtonGroup
  * @param viewModel ViewModel that manages state and handles user actions (vault, profile management, encryption, logging, clipboard).
  * @param uiState Current UI state used to populate fields, available profiles, and active profile information.
  */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
     val context = LocalContext.current
@@ -238,25 +236,20 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
                         items = uiState.availableProfiles,
                         key = { it.id }
                     ) { profile ->
-                        Modifier.animateItem(placementSpec = tween(durationMillis = 300))
-
                         ExpandableProfileCard(
                             profile = profile,
                             isActive = profile.id == uiState.activeProfile.id,
                             onSelect = {
                                 viewModel.selectProfile(it)
-                                // UPDATED: Use helper
                                 showToast("Activated: ${it.name}")
                             },
                             onEdit = {
                                 viewModel.loadProfileToCustomMode(it)
                                 showProfileSheet = false
-                                // UPDATED: Use helper
                                 showToast("Editing ${it.name}")
                             },
                             onDelete = {
                                 viewModel.deleteProfile(it.id)
-                                // UPDATED: Use helper
                                 showToast("Profile deleted")
                             }
                         )
@@ -271,16 +264,8 @@ fun EncryptionInterface(viewModel: SigilViewModel, uiState: UiState) {
  * Renders an expandable card for an encryption profile that shows name, badges, algorithm chain,
  * active state, and provides actions to select, edit, delete, and view per-algorithm details.
  *
- * The card toggles between a compact header and expanded details, highlights the active profile,
- * displays warnings for weak algorithms, and shows an algorithm info dialog when an algorithm chip is tapped.
- *
- * @param profile The EncryptionProfile to display.
- * @param isActive Whether this profile is currently active; affects visual emphasis and the action shown.
- * @param onSelect Callback invoked with the profile when the user chooses to use this profile.
- * @param onEdit Callback invoked with the profile when the user requests to edit it.
- * @param onDelete Callback invoked with the profile when the user requests to delete it.
+ * Broken down into sub-components (Header, BadgeRow, ExpandedContent) to reduce complexity.
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ExpandableProfileCard(
     profile: EncryptionProfile,
@@ -313,197 +298,281 @@ fun ExpandableProfileCard(
         shape = RoundedCornerShape(12.dp)
     ) {
         Column(Modifier.padding(12.dp)) {
-            // --- HEADER ROW (Always Visible) ---
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                // Left Side: Name + Badges
-                Column(modifier = Modifier.weight(1f)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(profile.name, fontWeight = FontWeight.Bold, fontSize = 16.sp)
-                        if (isActive) {
-                            Spacer(Modifier.width(6.dp))
-                            Icon(Icons.Default.CheckCircle, null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
-                        }
-                    }
-
-                    Spacer(Modifier.height(4.dp))
-
-                    // Mini Badges Row
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        if (profile.isBuiltIn) {
-                            BadgeText("Built-in", MaterialTheme.colorScheme.secondary)
-                            Spacer(Modifier.width(6.dp))
-                        }
-
-                        // Algo Count
-                        BadgeText("${profile.layers.size} Algos")
-
-                        // Compression
-                        if (profile.isCompressionEnabled && !profile.isRaw) {
-                            Spacer(Modifier.width(6.dp))
-                            BadgeText("CMP", MaterialTheme.colorScheme.tertiary)
-                        }
-
-                        // KDF
-                        if (profile.kdfConfig != null) {
-                            Spacer(Modifier.width(6.dp))
-                            BadgeText("KDF+", MaterialTheme.colorScheme.tertiary)
-                        }
-
-                        // Weak Warning
-                        if (isWeak) {
-                            Spacer(Modifier.width(6.dp))
-                            BadgeText("Weak", MaterialTheme.colorScheme.error)
-                        }
-
-                        // Raw Badge
-                        if (profile.isRaw) {
-                            Spacer(Modifier.width(6.dp))
-                            BadgeText("RAW", MaterialTheme.colorScheme.tertiary)
-                        }
-                    }
-                }
-
-                // Right Side: Selection Action + Expand
-                Row(verticalAlignment = Alignment.CenterVertically) {
-
-                    // SWITCHING LOGIC: Use vs Active Badge
-                    AnimatedVisibility(visible = !isActive) {
-                        OutlinedButton(
-                            onClick = { onSelect(profile) },
-                            modifier = Modifier.height(36.dp),
-                            contentPadding = PaddingValues(horizontal = 12.dp),
-                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
-                        ) {
-                            Text("Use")
-                        }
-                    }
-
-                    AnimatedVisibility(visible = isActive) {
-                        // Badge style button for Active state
-                        Button(
-                            onClick = {},
-                            enabled = false,
-                            modifier = Modifier.height(36.dp),
-                            contentPadding = PaddingValues(horizontal = 12.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                disabledContainerColor = MaterialTheme.colorScheme.primary,
-                                disabledContentColor = MaterialTheme.colorScheme.onPrimary
-                            )
-                        ) {
-                            Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp))
-                            Spacer(Modifier.width(6.dp))
-                            Text("Active")
-                        }
-                    }
-
-                    Spacer(Modifier.width(8.dp))
-
-                    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "ExpandArrow")
-                    Icon(
-                        Icons.Default.ExpandMore,
-                        null,
-                        modifier = Modifier.rotate(rotation),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
+            // --- HEADER (Always Visible) ---
+            ProfileCardHeader(
+                profile = profile,
+                isActive = isActive,
+                isWeak = isWeak,
+                expanded = expanded,
+                onSelect = onSelect
+            )
 
             // --- EXPANDED CONTENT ---
             AnimatedVisibility(visible = expanded) {
-                Column(Modifier.padding(top = 12.dp)) {
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                    Spacer(Modifier.height(8.dp))
-
-                    // Description
-                    if (profile.description.isNotBlank()) {
-                        Text(
-                            profile.description,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(Modifier.height(8.dp))
-                    }
-
-                    // Layer Chain Flow
-                    Text("Algorithm Chain (Tap for info):", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
-                    FlowRow(
-                        modifier = Modifier.padding(top = 4.dp),
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        profile.layers.forEachIndexed { index, algo ->
-                            SuggestionChip(
-                                onClick = { algoInfoDialog = algo },
-                                label = { Text(algo.name.replace("_", "-")) },
-                                colors = SuggestionChipDefaults.suggestionChipColors(
-                                    containerColor = MaterialTheme.colorScheme.surface
-                                ),
-                                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-                                modifier = Modifier.height(24.dp)
-                            )
-                            if (index < profile.layers.size - 1) {
-                                Icon(Icons.AutoMirrored.Filled.ArrowForward, null, modifier = Modifier.size(12.dp).align(Alignment.CenterVertically), tint = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                        }
-                    }
-
-                    if (!profile.isBuiltIn) {
-                        Spacer(Modifier.height(16.dp))
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End
-                        ) {
-                            OutlinedButton(
-                                onClick = { onDelete(profile) },
-                                contentPadding = PaddingValues(horizontal = 12.dp),
-                                modifier = Modifier.height(32.dp),
-                                colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
-                            ) {
-                                Icon(Icons.Default.Delete, null, Modifier.size(14.dp))
-                            }
-                            Spacer(Modifier.width(8.dp))
-                            OutlinedButton(
-                                onClick = { onEdit(profile) },
-                                contentPadding = PaddingValues(horizontal = 12.dp),
-                                modifier = Modifier.height(32.dp)
-                            ) {
-                                Icon(Icons.Default.Edit, null, Modifier.size(14.dp))
-                                Spacer(Modifier.width(4.dp))
-                                Text("Edit", fontSize = 12.sp)
-                            }
-                        }
-                    }
-                }
+                ProfileExpandedContent(
+                    profile = profile,
+                    onChipClick = { algoInfoDialog = it },
+                    onEdit = onEdit,
+                    onDelete = onDelete
+                )
             }
         }
     }
 
     // ALGO INFO DIALOG
-    algoInfoDialog?.let { algo ->
-        val details = AlgorithmRegistry.supportedAlgorithms.find { it.id == algo.name }
-        AlertDialog(
-            onDismissRequest = { algoInfoDialog = null },
-            icon = { Icon(Icons.Default.Info, null) },
-            title = { Text(details?.name ?: algo.name) },
-            text = {
-                Column {
-                    Text(details?.description ?: "No description available.")
-                    Spacer(Modifier.height(8.dp))
-                    Text("Type: ${details?.type ?: "Unknown"}", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
-                    if (details?.isWeak == true) {
-                        Text("Warning: ${details.securityWarning}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
-                    }
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = { algoInfoDialog = null }) { Text("Close") }
-            }
+    if (algoInfoDialog != null) {
+        AlgorithmInfoDialog(
+            algo = algoInfoDialog!!,
+            onDismiss = { algoInfoDialog = null }
         )
     }
+}
+
+/**
+ * Sub-component: Displays the top row of the card (Name, badges, action button, arrow).
+ */
+@Composable
+private fun ProfileCardHeader(
+    profile: EncryptionProfile,
+    isActive: Boolean,
+    isWeak: Boolean,
+    expanded: Boolean,
+    onSelect: (EncryptionProfile) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        // Left Side: Name + Badges
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(profile.name, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                if (isActive) {
+                    Spacer(Modifier.width(6.dp))
+                    Icon(Icons.Default.CheckCircle, null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
+                }
+            }
+
+            Spacer(Modifier.height(4.dp))
+            ProfileBadgeRow(profile, isWeak)
+        }
+
+        // Right Side: Selection Action + Expand Arrow
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            // Use vs Active Button
+            AnimatedVisibility(visible = !isActive) {
+                OutlinedButton(
+                    onClick = { onSelect(profile) },
+                    modifier = Modifier.height(36.dp),
+                    contentPadding = PaddingValues(horizontal = 12.dp),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
+                ) {
+                    Text("Use")
+                }
+            }
+
+            AnimatedVisibility(visible = isActive) {
+                Button(
+                    onClick = {},
+                    enabled = false,
+                    modifier = Modifier.height(36.dp),
+                    contentPadding = PaddingValues(horizontal = 12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        disabledContainerColor = MaterialTheme.colorScheme.primary,
+                        disabledContentColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                ) {
+                    Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Active")
+                }
+            }
+
+            Spacer(Modifier.width(8.dp))
+
+            val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "ExpandArrow")
+            Icon(
+                Icons.Default.ExpandMore,
+                null,
+                modifier = Modifier.rotate(rotation),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/**
+ * Sub-component: Displays the row of small badges (Built-in, Count, CMP, KDF, Weak).
+ */
+@Composable
+private fun ProfileBadgeRow(profile: EncryptionProfile, isWeak: Boolean) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (profile.isBuiltIn) {
+            BadgeText("Built-in", MaterialTheme.colorScheme.secondary)
+            Spacer(Modifier.width(6.dp))
+        }
+
+        // Algo Count
+        BadgeText("${profile.layers.size} Algos")
+
+        // Compression
+        if (profile.isCompressionEnabled && !profile.isRaw) {
+            Spacer(Modifier.width(6.dp))
+            BadgeText("CMP", MaterialTheme.colorScheme.tertiary)
+        }
+
+        // KDF
+        if (profile.kdfConfig != null) {
+            Spacer(Modifier.width(6.dp))
+            BadgeText("KDF+", MaterialTheme.colorScheme.tertiary)
+        }
+
+        // Weak Warning
+        if (isWeak) {
+            Spacer(Modifier.width(6.dp))
+            BadgeText("Weak", MaterialTheme.colorScheme.error)
+        }
+
+        // Raw Badge
+        if (profile.isRaw) {
+            Spacer(Modifier.width(6.dp))
+            BadgeText("RAW", MaterialTheme.colorScheme.tertiary)
+        }
+    }
+}
+
+/**
+ * Sub-component: Displays the content shown when the card is expanded (Description, Chips, Edit/Delete Actions).
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ProfileExpandedContent(
+    profile: EncryptionProfile,
+    onChipClick: (CryptoEngine.Algorithm) -> Unit,
+    onEdit: (EncryptionProfile) -> Unit,
+    onDelete: (EncryptionProfile) -> Unit
+) {
+    Column(Modifier.padding(top = 12.dp)) {
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        Spacer(Modifier.height(8.dp))
+
+        // Description
+        if (profile.description.isNotBlank()) {
+            Text(
+                profile.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(8.dp))
+        }
+
+        // Layer Chain Flow
+        Text("Algorithm Chain (Tap for info):", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+        FlowRow(
+            modifier = Modifier.padding(top = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            profile.layers.forEachIndexed { index, algo ->
+                SuggestionChip(
+                    onClick = { onChipClick(algo) },
+                    label = { Text(algo.name.replace("_", "-")) },
+                    colors = SuggestionChipDefaults.suggestionChipColors(
+                        containerColor = MaterialTheme.colorScheme.surface
+                    ),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                    modifier = Modifier.height(24.dp)
+                )
+                if (index < profile.layers.size - 1) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowForward,
+                        null,
+                        modifier = Modifier
+                            .size(12.dp)
+                            .align(Alignment.CenterVertically),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        if (!profile.isBuiltIn) {
+            Spacer(Modifier.height(16.dp))
+            ProfileActionButtons(
+                profile = profile,
+                onEdit = onEdit,
+                onDelete = onDelete
+            )
+        }
+    }
+}
+
+/**
+ * Sub-component: Edit and Delete buttons for the expanded view.
+ */
+@Composable
+private fun ProfileActionButtons(
+    profile: EncryptionProfile,
+    onEdit: (EncryptionProfile) -> Unit,
+    onDelete: (EncryptionProfile) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End
+    ) {
+        OutlinedButton(
+            onClick = { onDelete(profile) },
+            contentPadding = PaddingValues(horizontal = 12.dp),
+            modifier = Modifier.height(32.dp),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
+        ) {
+            Icon(Icons.Default.Delete, null, Modifier.size(14.dp))
+        }
+        Spacer(Modifier.width(8.dp))
+        OutlinedButton(
+            onClick = { onEdit(profile) },
+            contentPadding = PaddingValues(horizontal = 12.dp),
+            modifier = Modifier.height(32.dp)
+        ) {
+            Icon(Icons.Default.Edit, null, Modifier.size(14.dp))
+            Spacer(Modifier.width(4.dp))
+            Text("Edit", fontSize = 12.sp)
+        }
+    }
+}
+
+/**
+ * Sub-component: The Alert Dialog showing algorithm details.
+ */
+@Composable
+private fun AlgorithmInfoDialog(
+    algo: CryptoEngine.Algorithm,
+    onDismiss: () -> Unit
+) {
+    val details = AlgorithmRegistry.supportedAlgorithms.find { it.id == algo.name }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Info, null) },
+        title = { Text(details?.name ?: algo.name) },
+        text = {
+            Column {
+                Text(details?.description ?: "No description available.")
+                Spacer(Modifier.height(8.dp))
+                Text("Type: ${details?.type ?: "Unknown"}", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
+                if (details?.isWeak == true) {
+                    Text(
+                        "Warning: ${details.securityWarning ?: "Weak cipher"}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        }
+    )
 }
 
 /**

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/EncryptionScreen.kt
@@ -320,9 +320,9 @@ fun ExpandableProfileCard(
     }
 
     // ALGO INFO DIALOG
-    if (algoInfoDialog != null) {
+    algoInfoDialog?.let { algo ->
         AlgorithmInfoDialog(
-            algo = algoInfoDialog!!,
+            algo = algo,
             onDismiss = { algoInfoDialog = null }
         )
     }

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/LockScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/LockScreen.kt
@@ -93,6 +93,12 @@ fun LockScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
+                if (BiometricHelper.hasBiometricChanged()) {
+                    showBiometricInvalidatedDialog = true
+                    isPinFallback = true
+                    return@LifecycleEventObserver
+                }
+
                 if (lockMode == LockMode.DEVICE &&
                     !showBiometricInvalidatedDialog &&
                     !isPinFallback

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/LockScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/LockScreen.kt
@@ -33,6 +33,18 @@ import dev.animeshvarma.sigil.SigilViewModel
 import dev.animeshvarma.sigil.model.LockMode
 import dev.animeshvarma.sigil.util.BiometricHelper
 
+/**
+ * Render the Sigil lock screen and manage PIN and biometric authentication flows.
+ *
+ * This composable displays either a PIN entry UI or a biometric unlock button depending on
+ * the configured lock mode and runtime state, verifies PIN via the provided ViewModel,
+ * triggers biometric prompts (including automatic prompt on lifecycle resume when applicable),
+ * and shows dialogs for biometric invalidation and emergency reset. On successful authentication
+ * it invokes the provided unlock callback.
+ *
+ * @param viewModel The SigilViewModel used to read preferences, verify the app PIN, and perform data wipe.
+ * @param onUnlock Callback invoked when authentication succeeds (PIN verified or biometric success).
+ */
 @Composable
 fun LockScreen(
     viewModel: SigilViewModel,

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/LockScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/LockScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import dev.animeshvarma.sigil.SigilViewModel
 import dev.animeshvarma.sigil.model.LockMode
 import dev.animeshvarma.sigil.util.BiometricHelper
@@ -38,6 +40,7 @@ fun LockScreen(
 ) {
     val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     val prefs = viewModel.getPrefs()
     val uiState by viewModel.uiState.collectAsState()
 
@@ -46,20 +49,17 @@ fun LockScreen(
     var pinInput by remember { mutableStateOf("") }
     var showError by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
-
     var isPinFallback by remember { mutableStateOf(false) }
-
     var showWipeDialog by remember { mutableStateOf(false) }
-
     var showBiometricInvalidatedDialog by remember { mutableStateOf(false) }
 
+    // Helper to trigger bio
     fun triggerBiometric() {
         if (context is FragmentActivity) {
             BiometricHelper.showPrompt(
                 activity = context,
                 onSuccess = { _ -> onUnlock() },
                 onFailure = {
-                    isPinFallback = true
                 },
                 onError = { error ->
                     showError = true
@@ -76,8 +76,22 @@ fun LockScreen(
             showBiometricInvalidatedDialog = true
             isPinFallback = true
         }
-        else if (lockMode == LockMode.DEVICE) {
-            triggerBiometric()
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (lockMode == LockMode.DEVICE &&
+                    !showBiometricInvalidatedDialog &&
+                    !isPinFallback
+                ) {
+                    triggerBiometric()
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 
@@ -195,6 +209,7 @@ fun LockScreen(
                     }
                 }
 
+                // Retry Biometrics Button (Only if valid)
                 if (lockMode == LockMode.DEVICE && isPinFallback && !BiometricHelper.hasBiometricChanged()) {
                     Spacer(Modifier.height(16.dp))
                     TextButton(onClick = { triggerBiometric() }) {
@@ -205,7 +220,6 @@ fun LockScreen(
                 }
 
             } else {
-                // Biometric Button State
                 Button(
                     onClick = { triggerBiometric() },
                     modifier = Modifier.fillMaxWidth().height(50.dp),
@@ -229,7 +243,6 @@ fun LockScreen(
     if (showBiometricInvalidatedDialog) {
         AlertDialog(
             onDismissRequest = {
-                showBiometricInvalidatedDialog = false
             },
             icon = {
                 Icon(Icons.Default.Security, null, tint = MaterialTheme.colorScheme.primary)

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
@@ -154,7 +154,7 @@ fun SettingsScreen(viewModel: SigilViewModel) {
                         Icons.Default.Warning,
                         contentDescription = "Warning",
                         tint = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(15.dp)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material.icons.filled.SettingsBackupRestore
 import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.material.icons.filled.Warning
@@ -108,7 +107,6 @@ fun SettingsScreen(viewModel: SigilViewModel) {
     var showSecurityErrorDialog by remember { mutableStateOf(false) }
 
     // Danger Dialogs
-    var showResetProfilesDialog by remember { mutableStateOf(false) }
     var showResetSettingsDialog by remember { mutableStateOf(false) }
     var showWipeDataDialog by remember { mutableStateOf(false) }
 
@@ -387,7 +385,6 @@ fun SettingsScreen(viewModel: SigilViewModel) {
                             onValueChange = { graceMinutes = it },
                             onValueChangeFinished = { prefs.graceDurationMinutes = graceMinutes.toInt() },
                             valueRange = 1f..60f,
-                            steps = 59
                         )
                     }
                 }
@@ -436,19 +433,6 @@ fun SettingsScreen(viewModel: SigilViewModel) {
 
         // --- DATA & PROFILES ---
         SettingsHeader("Data Management")
-
-        OutlinedButton(
-            onClick = { showResetProfilesDialog = true },
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(12.dp),
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.secondary)
-        ) {
-            Icon(Icons.Default.Restore, null, Modifier.size(18.dp))
-            Spacer(Modifier.width(8.dp))
-            Text("Reset Encryption Profiles")
-        }
-
-        Spacer(Modifier.height(8.dp))
 
         OutlinedButton(
             onClick = { showResetSettingsDialog = true },
@@ -623,38 +607,64 @@ fun SettingsScreen(viewModel: SigilViewModel) {
         )
     }
 
-    // CONFIRM RESET PROFILES
-    if (showResetProfilesDialog) {
-        AlertDialog(
-            onDismissRequest = { showResetProfilesDialog = false },
-            icon = { Icon(Icons.Default.Restore, null) },
-            title = { Text("Reset Profiles") },
-            text = { Text("Delete all custom encryption profiles and restore the default list?\n\nThis cannot be undone.") },
-            confirmButton = {
-                Button(onClick = {
-                    viewModel.resetProfiles()
-                    showResetProfilesDialog = false
-                }) { Text("Reset") }
-            },
-            dismissButton = {
-                TextButton(onClick = { showResetProfilesDialog = false }) { Text("Cancel") }
-            }
-        )
-    }
-
     // CONFIRM RESET SETTINGS
     if (showResetSettingsDialog) {
         var shouldRestart by remember { mutableStateOf(false) }
+        var resetAll by remember { mutableStateOf(true) }
+        var resetGeneral by remember { mutableStateOf(true) }
+        var resetAppearance by remember { mutableStateOf(true) }
+        var resetKdf by remember { mutableStateOf(true) }
+        var resetProfiles by remember { mutableStateOf(true) }
 
         AlertDialog(
             onDismissRequest = { showResetSettingsDialog = false },
             icon = { Icon(Icons.Default.SettingsBackupRestore, null) },
-            title = { Text("Reset Preferences") },
+            title = { Text("Reset App Preferences") },
             text = {
                 Column {
-                    Text("Reset all application settings (Theme, Security, KDF) to defaults?\n\nThis will update the UI immediately, application of some changes will require a restart.")
-
+                    Text("Select which settings you want to restore to default values.")
                     Spacer(modifier = Modifier.height(16.dp))
+
+                    // Reset All Checkbox
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { resetAll = !resetAll },
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = resetAll,
+                            onCheckedChange = { resetAll = it }
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Reset Everything", fontWeight = FontWeight.Bold)
+                    }
+
+                    AnimatedVisibility(visible = !resetAll) {
+                        Column(modifier = Modifier.padding(start = 12.dp)) {
+                            // Helper composable
+                            @Composable
+                            fun ResetOption(label: String, state: Boolean, onStateChange: (Boolean) -> Unit) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable { onStateChange(!state) },
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Checkbox(checked = state, onCheckedChange = onStateChange)
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(label)
+                                }
+                            }
+
+                            ResetOption("General, Privacy & App Lock", resetGeneral) { resetGeneral = it }
+                            ResetOption("Appearance Settings", resetAppearance) { resetAppearance = it }
+                            ResetOption("Global Encryption Defaults", resetKdf) { resetKdf = it }
+                            ResetOption("Saved Encryption Profiles", resetProfiles) { resetProfiles = it }
+                        }
+                    }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
 
                     Row(
                         modifier = Modifier
@@ -673,31 +683,46 @@ fun SettingsScreen(viewModel: SigilViewModel) {
             },
             confirmButton = {
                 Button(onClick = {
-                    // 1. Save defaults to SharedPreferences (and Restart if checked)
-                    viewModel.resetAppPreferences(shouldRestart)
+                    val finalGeneral = if (resetAll) true else resetGeneral
+                    val finalAppearance = if (resetAll) true else resetAppearance
+                    val finalKdf = if (resetAll) true else resetKdf
+                    val finalProfiles = if (resetAll) true else resetProfiles
 
-                    // 2. IF NOT RESTARTING, MANUALLY UPDATE UI STATE
-                    if (!shouldRestart) {
-                        onboardingToggle = true
+                    // Perform Reset via Prefs
+                    prefs.resetSettings(
+                        resetGeneral = finalGeneral,
+                        resetAppearance = finalAppearance,
+                        resetKdf = finalKdf,
+                        resetProfiles = finalProfiles,
+                        synchronous = shouldRestart
+                    )
 
-                        // Security
-                        lockMode = LockMode.NONE
-                        graceEnabled = false
-                        graceMinutes = 5f
+                    if (shouldRestart) {
+                        restartApp(context)
+                    } else {
+                        // Manually update UI state
+                        val freshPrefs = viewModel.getPrefs()
 
-                        // KDF (Defaults based on your ViewModel/Prefs)
-                        kdfIterations = 10f
-                        kdfMemory = 16f
-                        kdfParallelism = 4f
+                        if (finalGeneral) {
+                            onboardingToggle = true
+                            lockMode = freshPrefs.lockMode
+                            graceEnabled = freshPrefs.isGracePeriodEnabled
+                            graceMinutes = freshPrefs.graceDurationMinutes.toFloat()
+                            screenShield = freshPrefs.isScreenShieldEnabled
+                            clipTimeout = freshPrefs.clipboardTimeoutSeconds.toFloat()
+                        }
 
-                        // Privacy
-                        clipTimeout = 30f
-                        screenShield = true
+                        if (finalAppearance) {
+                            dynamicColors = freshPrefs.isDynamicColorsEnabled
+                            darkMode = freshPrefs.isDarkModeEnabled
+                            selectedColorInt = freshPrefs.selectedThemeColor
+                        }
 
-                        // Appearance
-                        dynamicColors = true
-                        darkMode = true
-                        selectedColorInt = android.graphics.Color.WHITE // 0xFFFFFFFF
+                        if (finalKdf) {
+                            kdfIterations = freshPrefs.kdfIterations.toFloat()
+                            kdfMemory = freshPrefs.kdfMemoryPow2.toFloat()
+                            kdfParallelism = freshPrefs.kdfParallelism.toFloat()
+                        }
                     }
 
                     showResetSettingsDialog = false

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
@@ -19,8 +19,11 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material.icons.filled.SettingsBackupRestore
 import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
@@ -40,6 +43,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.graphics.toColorInt
 import dev.animeshvarma.sigil.SigilViewModel
 import dev.animeshvarma.sigil.model.LockMode
 import dev.animeshvarma.sigil.ui.components.SigilSegmentedControl
@@ -87,6 +91,11 @@ fun SettingsScreen(viewModel: SigilViewModel) {
     var showVerifyPinDialog by remember { mutableStateOf(false) }
     var showColorDialog by remember { mutableStateOf(false) }
     var showSecurityErrorDialog by remember { mutableStateOf(false) }
+
+    // Danger Dialogs
+    var showResetProfilesDialog by remember { mutableStateOf(false) }
+    var showResetSettingsDialog by remember { mutableStateOf(false) }
+    var showWipeDataDialog by remember { mutableStateOf(false) }
 
     var isSavingPin by remember { mutableStateOf(false) }
 
@@ -149,7 +158,7 @@ fun SettingsScreen(viewModel: SigilViewModel) {
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = "These settings must match exactly for encryption and decryption. Only change if you know what you are doing.",
+                        text = "Global defaults. Profiles may override this.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.error,
                         fontWeight = FontWeight.Medium
@@ -408,6 +417,48 @@ fun SettingsScreen(viewModel: SigilViewModel) {
             }
         }
 
+        Spacer(Modifier.height(24.dp))
+
+        // --- DATA & PROFILES ---
+        SettingsHeader("Data Management")
+
+        OutlinedButton(
+            onClick = { showResetProfilesDialog = true },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.secondary)
+        ) {
+            Icon(Icons.Default.Restore, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("Reset Encryption Profiles")
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        OutlinedButton(
+            onClick = { showResetSettingsDialog = true },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.secondary)
+        ) {
+            Icon(Icons.Default.SettingsBackupRestore, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("Reset App Preferences")
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        Button(
+            onClick = { showWipeDataDialog = true },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+        ) {
+            Icon(Icons.Default.DeleteForever, null, Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("Wipe All Data")
+        }
+
         Spacer(Modifier.height(64.dp))
     }
 
@@ -556,6 +607,63 @@ fun SettingsScreen(viewModel: SigilViewModel) {
             }
         )
     }
+
+    // CONFIRM RESET PROFILES
+    if (showResetProfilesDialog) {
+        AlertDialog(
+            onDismissRequest = { showResetProfilesDialog = false },
+            icon = { Icon(Icons.Default.Restore, null) },
+            title = { Text("Reset Profiles") },
+            text = { Text("Delete all custom encryption profiles and restore the default list?\n\nThis cannot be undone.") },
+            confirmButton = {
+                Button(onClick = {
+                    viewModel.resetProfiles()
+                    showResetProfilesDialog = false
+                }) { Text("Reset") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetProfilesDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    // CONFIRM RESET SETTINGS
+    if (showResetSettingsDialog) {
+        AlertDialog(
+            onDismissRequest = { showResetSettingsDialog = false },
+            icon = { Icon(Icons.Default.SettingsBackupRestore, null) },
+            title = { Text("Reset Preferences") },
+            text = { Text("Reset all application settings (Theme, Security, KDF) to defaults?\n\nThis will also clear any 'Remember my choice' saved decisions.") },
+            confirmButton = {
+                Button(onClick = {
+                    viewModel.resetAppPreferences()
+                    showResetSettingsDialog = false
+                }) { Text("Reset") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetSettingsDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    // CONFIRM WIPE ALL
+    if (showWipeDataDialog) {
+        AlertDialog(
+            onDismissRequest = { showWipeDataDialog = false },
+            icon = { Icon(Icons.Default.DeleteForever, null, tint = MaterialTheme.colorScheme.error) },
+            title = { Text("Scorched Earth") },
+            text = { Text("This will permanently delete ALL data, including:\n- Keys in Vault\n- Settings & Profiles\n- PINs & Biometrics\n\nThe app will restart.") },
+            confirmButton = {
+                Button(
+                    onClick = { viewModel.wipeAllData() },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("NUKE IT") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showWipeDataDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
 }
 
 @Composable
@@ -625,7 +733,8 @@ fun AdvancedColorPickerDialog(
     fun updateFromHex(hex: String) {
         try {
             if (hex.length == 6) {
-                val color = Color(android.graphics.Color.parseColor("#$hex"))
+                // Fix: Use KTX toColorInt for cleaner logic
+                val color = Color("#$hex".toColorInt())
                 currentColor = color
                 android.graphics.Color.colorToHSV(color.toArgb(), hsv.value)
                 updateInputs(color)

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
@@ -55,6 +55,21 @@ import kotlin.math.roundToInt
 import kotlin.math.sin
 import kotlin.system.exitProcess
 
+/**
+ * Renders the app Settings screen with controls for general options, encryption parameters, privacy, app lock, appearance, and data management.
+ *
+ * Displays interactive sections and dialogs for:
+ * - General (onboarding reset, restart),
+ * - Encryption Parameters (Argon2 settings),
+ * - Privacy & Clipboard (screen shield, clipboard auto-wipe),
+ * - App Lock (PIN/biometrics, grace period, PIN management),
+ * - Appearance (dynamic colors, accent color, dark mode),
+ * - Data Management (reset profiles, reset preferences, wipe all data).
+ *
+ * The UI synchronizes local state with the provided ViewModel and persists preference changes via the ViewModel/prefs. Dialogs handle PIN setup/verification, color selection, and confirmations for destructive actions.
+ *
+ * @param viewModel The SigilViewModel that provides preferences, performs preference updates, and exposes actions such as resetting profiles, resetting preferences, setting/wiping PINs, and wiping all data.
+ */
 @Composable
 fun SettingsScreen(viewModel: SigilViewModel) {
     val context = LocalContext.current
@@ -714,6 +729,14 @@ fun SettingsScreen(viewModel: SigilViewModel) {
     }
 }
 
+/**
+ * Displays a styled section header for settings screens.
+ *
+ * Renders the provided text using the theme's `labelLarge` typography and primary color,
+ * with leading and bottom padding to align with other settings content.
+ *
+ * @param text The header text to display.
+ */
 @Composable
 fun SettingsHeader(text: String) {
     Text(
@@ -749,6 +772,18 @@ fun RowScope.RGBField(label: String, value: String, onValueChange: (String) -> U
     )
 }
 
+/**
+ * Shows a dialog that lets the user pick an accent color using an HSV color wheel, a brightness slider,
+ * a 6-digit HEX input, or individual R/G/B inputs.
+ *
+ * The dialog initializes to `initialColor`. User interactions update an internal selected color;
+ * tapping "Apply" invokes `onColorSelected` with the current selection, and dismissing the dialog
+ * invokes `onDismiss`.
+ *
+ * @param initialColor The starting color shown when the dialog opens.
+ * @param onDismiss Called when the dialog is dismissed or the "Cancel" button is pressed.
+ * @param onColorSelected Called with the selected Color when the user confirms ("Apply").
+ */
 @Composable
 fun AdvancedColorPickerDialog(
     initialColor: Color,

--- a/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/ui/screens/SettingsScreen.kt
@@ -629,14 +629,62 @@ fun SettingsScreen(viewModel: SigilViewModel) {
 
     // CONFIRM RESET SETTINGS
     if (showResetSettingsDialog) {
+        var shouldRestart by remember { mutableStateOf(false) }
+
         AlertDialog(
             onDismissRequest = { showResetSettingsDialog = false },
             icon = { Icon(Icons.Default.SettingsBackupRestore, null) },
             title = { Text("Reset Preferences") },
-            text = { Text("Reset all application settings (Theme, Security, KDF) to defaults?\n\nThis will also clear any 'Remember my choice' saved decisions.") },
+            text = {
+                Column {
+                    Text("Reset all application settings (Theme, Security, KDF) to defaults?\n\nThis will update the UI immediately, application of some changes will require a restart.")
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { shouldRestart = !shouldRestart },
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = shouldRestart,
+                            onCheckedChange = { shouldRestart = it }
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Restart App immediately")
+                    }
+                }
+            },
             confirmButton = {
                 Button(onClick = {
-                    viewModel.resetAppPreferences()
+                    // 1. Save defaults to SharedPreferences (and Restart if checked)
+                    viewModel.resetAppPreferences(shouldRestart)
+
+                    // 2. IF NOT RESTARTING, MANUALLY UPDATE UI STATE
+                    if (!shouldRestart) {
+                        onboardingToggle = true
+
+                        // Security
+                        lockMode = LockMode.NONE
+                        graceEnabled = false
+                        graceMinutes = 5f
+
+                        // KDF (Defaults based on your ViewModel/Prefs)
+                        kdfIterations = 10f
+                        kdfMemory = 16f
+                        kdfParallelism = 4f
+
+                        // Privacy
+                        clipTimeout = 30f
+                        screenShield = true
+
+                        // Appearance
+                        dynamicColors = true
+                        darkMode = true
+                        selectedColorInt = android.graphics.Color.WHITE // 0xFFFFFFFF
+                    }
+
                     showResetSettingsDialog = false
                 }) { Text("Reset") }
             },

--- a/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
@@ -3,7 +3,11 @@ package dev.animeshvarma.sigil.util
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import dev.animeshvarma.sigil.crypto.CryptoEngine
+import dev.animeshvarma.sigil.model.EncryptionProfile
 import dev.animeshvarma.sigil.model.LockMode
+import org.json.JSONArray
+import org.json.JSONObject
 
 class SigilPreferences(context: Context) {
 
@@ -23,6 +27,7 @@ class SigilPreferences(context: Context) {
         private const val KEY_DYNAMIC_COLORS = "dynamic_colors_enabled"
         private const val KEY_DARK_MODE = "dark_mode_enabled"
         private const val KEY_THEME_COLOR = "theme_color_int"
+        private const val KEY_SAVED_PROFILES = "saved_encryption_profiles"
     }
 
     fun hasCompletedOnboarding(): Boolean {
@@ -91,4 +96,84 @@ class SigilPreferences(context: Context) {
     var kdfParallelism: Int
         get() = prefs.getInt(KEY_KDF_PARALLELISM, 4)
         set(value) = prefs.edit { putInt(KEY_KDF_PARALLELISM, value) }
+
+    // --- PROFILE PERSISTENCE ---
+    fun getCustomProfiles(): List<EncryptionProfile> {
+        val jsonString = prefs.getString(KEY_SAVED_PROFILES, "[]") ?: "[]"
+        val profiles = mutableListOf<EncryptionProfile>()
+
+        try {
+            val jsonArray = JSONArray(jsonString)
+            for (i in 0 until jsonArray.length()) {
+                val obj = jsonArray.getJSONObject(i)
+                try {
+                    val id = obj.getString("id")
+                    val name = obj.getString("name")
+                    val desc = obj.optString("description", "Custom Profile")
+                    val compress = obj.optBoolean("compress", true)
+
+                    // Parse Layers
+                    val layersArray = obj.getJSONArray("layers")
+                    val layers = mutableListOf<CryptoEngine.Algorithm>()
+                    for (j in 0 until layersArray.length()) {
+                        layers.add(CryptoEngine.Algorithm.valueOf(layersArray.getString(j)))
+                    }
+
+                    // Parse Optional KDF
+                    var kdfConfig: CryptoEngine.KdfConfig? = null
+                    if (obj.has("kdf")) {
+                        val kdfObj = obj.getJSONObject("kdf")
+                        kdfConfig = CryptoEngine.KdfConfig(
+                            iterations = kdfObj.getInt("iter"),
+                            memoryPow2 = kdfObj.getInt("mem"),
+                            parallelism = kdfObj.getInt("par")
+                        )
+                    }
+
+                    profiles.add(EncryptionProfile(
+                        id = id,
+                        name = name,
+                        description = desc,
+                        layers = layers,
+                        kdfConfig = kdfConfig,
+                        isBuiltIn = false,
+                        isCompressionEnabled = compress
+                    ))
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return profiles
+    }
+
+    fun saveCustomProfiles(profiles: List<EncryptionProfile>) {
+        val jsonArray = JSONArray()
+        profiles.filter { !it.isBuiltIn }.forEach { profile ->
+            val obj = JSONObject()
+            obj.put("id", profile.id)
+            obj.put("name", profile.name)
+            obj.put("description", profile.description)
+            obj.put("compress", profile.isCompressionEnabled)
+
+            val layersArray = JSONArray()
+            profile.layers.forEach { algo ->
+                layersArray.put(algo.name)
+            }
+            obj.put("layers", layersArray)
+
+            profile.kdfConfig?.let { kdf ->
+                val kdfObj = JSONObject()
+                kdfObj.put("iter", kdf.iterations)
+                kdfObj.put("mem", kdf.memoryPow2)
+                kdfObj.put("par", kdf.parallelism)
+                obj.put("kdf", kdfObj)
+            }
+
+            jsonArray.put(obj)
+        }
+        prefs.edit { putString(KEY_SAVED_PROFILES, jsonArray.toString()) }
+    }
 }

--- a/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
@@ -116,6 +116,7 @@ class SigilPreferences(context: Context) {
                     val name = obj.getString("name")
                     val desc = obj.optString("description", "Custom Profile")
                     val compress = obj.optBoolean("compress", true)
+                    val isRaw = obj.optBoolean("raw", false)
 
                     // Parse Layers
                     val layersArray = obj.getJSONArray("layers")
@@ -142,7 +143,8 @@ class SigilPreferences(context: Context) {
                         layers = layers,
                         kdfConfig = kdfConfig,
                         isBuiltIn = false,
-                        isCompressionEnabled = compress
+                        isCompressionEnabled = compress,
+                        isRaw = isRaw
                     ))
                 } catch (e: Exception) {
                     e.printStackTrace()
@@ -162,6 +164,7 @@ class SigilPreferences(context: Context) {
             obj.put("name", profile.name)
             obj.put("description", profile.description)
             obj.put("compress", profile.isCompressionEnabled)
+            obj.put("raw", profile.isRaw)
 
             val layersArray = JSONArray()
             profile.layers.forEach { algo ->
@@ -180,5 +183,27 @@ class SigilPreferences(context: Context) {
             jsonArray.put(obj)
         }
         prefs.edit { putString(KEY_SAVED_PROFILES, jsonArray.toString()) }
+    }
+
+    fun resetAllSettings(synchronous: Boolean) {
+        prefs.edit(commit = synchronous) {
+            // Security & General
+            putString(KEY_LOCK_MODE, LockMode.NONE.name)
+            putBoolean(KEY_GRACE_ENABLED, false)
+            putInt(KEY_GRACE_MINUTES, 5)
+            putBoolean(KEY_SCREEN_SHIELD, true)
+            putInt(KEY_CLIPBOARD_TIMEOUT, 30)
+            putBoolean(KEY_ONBOARDING_COMPLETED, false)
+
+            // Appearance
+            putBoolean(KEY_DYNAMIC_COLORS, true)
+            putBoolean(KEY_DARK_MODE, true)
+            putInt(KEY_THEME_COLOR, 0xFFFFFFFF.toInt())
+
+            // KDF Defaults
+            putInt(KEY_KDF_ITERATIONS, 10)
+            putInt(KEY_KDF_MEMORY, 16)
+            putInt(KEY_KDF_PARALLELISM, 4)
+        }
     }
 }

--- a/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
@@ -142,6 +142,7 @@ class SigilPreferences(context: Context) {
                     for (j in 0 until layersArray.length()) {
                         layers.add(CryptoEngine.Algorithm.valueOf(layersArray.getString(j)))
                     }
+                    if (layers.isEmpty()) throw IllegalArgumentException("Profile has no layers")
 
                     // Parse Optional KDF
                     var kdfConfig: CryptoEngine.KdfConfig? = null

--- a/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
@@ -3,11 +3,14 @@ package dev.animeshvarma.sigil.util
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import android.util.Log
 import dev.animeshvarma.sigil.crypto.CryptoEngine
 import dev.animeshvarma.sigil.model.EncryptionProfile
 import dev.animeshvarma.sigil.model.LockMode
 import org.json.JSONArray
 import org.json.JSONObject
+
+private const val TAG = "SigilPreferences"
 
 class SigilPreferences(context: Context) {
 
@@ -162,11 +165,11 @@ class SigilPreferences(context: Context) {
                         isRaw = isRaw
                     ))
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    Log.w(TAG, "Failed to parse profile at index $i", e)
                 }
             }
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to parse saved profiles JSON", e)
         }
         return profiles
     }

--- a/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
@@ -209,32 +209,51 @@ class SigilPreferences(context: Context) {
     }
 
     /**
-     * Reset all stored user preferences to their predefined defaults.
+     * Resets specific categories of user preferences.
      *
-     * This restores default values for security & general settings (lock mode, grace period, clipboard timeout, onboarding),
-     * appearance settings (dynamic colors, dark mode, theme color), and KDF parameters (iterations, memory, parallelism).
-     *
-     * @param synchronous If `true`, write the changes synchronously (commit); if `false`, schedule the write asynchronously (apply).
+     * @param resetGeneral Security, Lock Mode, Onboarding, Screen Shield, Clipboard.
+     * @param resetAppearance Dynamic Colors, Dark Mode, Theme Color.
+     * @param resetKdf Iterations, Memory, Parallelism.
+     * @param resetProfiles Saved Encryption Profiles and Active Profile ID.
+     * @param synchronous If `true`, write changes synchronously.
      */
-    fun resetAllSettings(synchronous: Boolean) {
+    fun resetSettings(
+        resetGeneral: Boolean,
+        resetAppearance: Boolean,
+        resetKdf: Boolean,
+        resetProfiles: Boolean,
+        synchronous: Boolean
+    ) {
         prefs.edit(commit = synchronous) {
-            // Security & General
-            putString(KEY_LOCK_MODE, LockMode.NONE.name)
-            putBoolean(KEY_GRACE_ENABLED, false)
-            putInt(KEY_GRACE_MINUTES, 5)
-            putBoolean(KEY_SCREEN_SHIELD, true)
-            putInt(KEY_CLIPBOARD_TIMEOUT, 30)
-            putBoolean(KEY_ONBOARDING_COMPLETED, false)
+            if (resetGeneral) {
+                // Security & General
+                putString(KEY_LOCK_MODE, LockMode.NONE.name)
+                putBoolean(KEY_GRACE_ENABLED, false)
+                putInt(KEY_GRACE_MINUTES, 5)
+                putBoolean(KEY_SCREEN_SHIELD, true)
+                putInt(KEY_CLIPBOARD_TIMEOUT, 30)
+                putBoolean(KEY_ONBOARDING_COMPLETED, false)
+            }
 
-            // Appearance
-            putBoolean(KEY_DYNAMIC_COLORS, true)
-            putBoolean(KEY_DARK_MODE, true)
-            putInt(KEY_THEME_COLOR, 0xFFFFFFFF.toInt())
+            if (resetAppearance) {
+                // Appearance
+                putBoolean(KEY_DYNAMIC_COLORS, true)
+                putBoolean(KEY_DARK_MODE, true)
+                putInt(KEY_THEME_COLOR, 0xFFFFFFFF.toInt())
+            }
 
-            // KDF Defaults
-            putInt(KEY_KDF_ITERATIONS, 10)
-            putInt(KEY_KDF_MEMORY, 16)
-            putInt(KEY_KDF_PARALLELISM, 4)
+            if (resetKdf) {
+                // KDF Defaults
+                putInt(KEY_KDF_ITERATIONS, 10)
+                putInt(KEY_KDF_MEMORY, 16)
+                putInt(KEY_KDF_PARALLELISM, 4)
+            }
+
+            if (resetProfiles) {
+                // Profiles
+                putString(KEY_SAVED_PROFILES, "[]")
+                remove(KEY_ACTIVE_PROFILE_ID)
+            }
         }
     }
 }

--- a/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
@@ -28,6 +28,7 @@ class SigilPreferences(context: Context) {
         private const val KEY_DARK_MODE = "dark_mode_enabled"
         private const val KEY_THEME_COLOR = "theme_color_int"
         private const val KEY_SAVED_PROFILES = "saved_encryption_profiles"
+        private const val KEY_ACTIVE_PROFILE_ID = "active_encryption_profile_id"
     }
 
     fun hasCompletedOnboarding(): Boolean {
@@ -98,6 +99,10 @@ class SigilPreferences(context: Context) {
         set(value) = prefs.edit { putInt(KEY_KDF_PARALLELISM, value) }
 
     // --- PROFILE PERSISTENCE ---
+    var activeProfileId: String?
+        get() = prefs.getString(KEY_ACTIVE_PROFILE_ID, null)
+        set(value) = prefs.edit { putString(KEY_ACTIVE_PROFILE_ID, value) }
+
     fun getCustomProfiles(): List<EncryptionProfile> {
         val jsonString = prefs.getString(KEY_SAVED_PROFILES, "[]") ?: "[]"
         val profiles = mutableListOf<EncryptionProfile>()

--- a/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
+++ b/app/src/main/java/dev/animeshvarma/sigil/util/SigilPreferences.kt
@@ -31,6 +31,11 @@ class SigilPreferences(context: Context) {
         private const val KEY_ACTIVE_PROFILE_ID = "active_encryption_profile_id"
     }
 
+    /**
+     * Indicates whether the onboarding flow has been completed.
+     *
+     * @return `true` if onboarding has been completed, `false` otherwise.
+     */
     fun hasCompletedOnboarding(): Boolean {
         return prefs.getBoolean(KEY_ONBOARDING_COMPLETED, false)
     }
@@ -103,6 +108,16 @@ class SigilPreferences(context: Context) {
         get() = prefs.getString(KEY_ACTIVE_PROFILE_ID, null)
         set(value) = prefs.edit { putString(KEY_ACTIVE_PROFILE_ID, value) }
 
+    /**
+     * Load custom encryption profiles persisted in shared preferences.
+     *
+     * Parses the JSON array stored under KEY_SAVED_PROFILES and reconstructs each saved EncryptionProfile.
+     * Malformed entries are skipped; missing optional fields use these defaults: `description` = "Custom Profile",
+     * `compress` = true, `raw` = false. Each profile's `layers` are parsed by algorithm name and an optional
+     * `kdf` object (with `iter`, `mem`, `par`) is converted to a KdfConfig when present.
+     *
+     * @return List of reconstructed custom EncryptionProfile objects; empty if none are saved or parsing fails.
+     */
     fun getCustomProfiles(): List<EncryptionProfile> {
         val jsonString = prefs.getString(KEY_SAVED_PROFILES, "[]") ?: "[]"
         val profiles = mutableListOf<EncryptionProfile>()
@@ -156,6 +171,14 @@ class SigilPreferences(context: Context) {
         return profiles
     }
 
+    /**
+     * Serializes the provided custom encryption profiles and saves them to shared preferences.
+     *
+     * Each profile is saved as a JSON object containing `id`, `name`, `description`, `compress`, `raw`,
+     * `layers` (array of algorithm names) and an optional `kdf` object with `iter`, `mem`, and `par`.
+     *
+     * @param profiles List of profiles to persist; built-in profiles are ignored.
+     */
     fun saveCustomProfiles(profiles: List<EncryptionProfile>) {
         val jsonArray = JSONArray()
         profiles.filter { !it.isBuiltIn }.forEach { profile ->
@@ -185,6 +208,14 @@ class SigilPreferences(context: Context) {
         prefs.edit { putString(KEY_SAVED_PROFILES, jsonArray.toString()) }
     }
 
+    /**
+     * Reset all stored user preferences to their predefined defaults.
+     *
+     * This restores default values for security & general settings (lock mode, grace period, clipboard timeout, onboarding),
+     * appearance settings (dynamic colors, dark mode, theme color), and KDF parameters (iterations, memory, parallelism).
+     *
+     * @param synchronous If `true`, write the changes synchronously (commit); if `false`, schedule the write asynchronously (apply).
+     */
     fun resetAllSettings(synchronous: Boolean) {
         prefs.edit(commit = synchronous) {
             // Security & General

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ foundation = "1.9.5"
 benchmarkCommon = "1.4.1"
 material3 = "1.4.0"
 material = "1.13.0"
+foundationVersion = "1.10.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -37,6 +38,7 @@ androidx-compose-foundation = { group = "androidx.compose.foundation", name = "f
 androidx-benchmark-common = { group = "androidx.benchmark", name = "benchmark-common", version.ref = "benchmarkCommon" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundationVersion" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ activityCompose = "1.11.0"
 composeBom = "2024.09.00"
 lifecycleViewmodelCompose = "2.9.4"
 bouncycastle = "1.76"
-foundation = "1.9.5"
 benchmarkCommon = "1.4.1"
 material3 = "1.4.0"
 material = "1.13.0"
@@ -34,7 +33,6 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 bouncycastle-bcpkix = { group = "org.bouncycastle", name = "bcpkix-jdk15to18", version.ref = "bouncycastle" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
-androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 androidx-benchmark-common = { group = "androidx.benchmark", name = "benchmark-common", version.ref = "benchmarkCommon" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }


### PR DESCRIPTION
This PR merges the **Encryption Profiles** feature, enabling users to save, manage, and switch between custom cipher cascades and standard configurations (for users who want clean encryption without the fuss of chaining).

### Changes
- **Encryption Profiles:** Implemented `EncryptionProfile` models and JSON persistence, allowing users to save custom cipher chains with specific KDF settings and descriptions.
- **Profile UI:** Added a bookmark-style selector sheet, "Built-in" vs "Custom" distinctions, and Conflict Resolution dialogs for profile management.
- **Raw Mode:** Added `isRaw` support to bypass Sigil packet headers for standard compatibility (e.g., generic AES-GCM). Updated "Standard AES" to use this mode by default.
- **Security Hardening:**
    - **Vault Safety:** Added duplicate key detection/overwrite warnings in `SecurePasswordInput`.
    - **Lifecycle:** Implemented stricter `ON_PAUSE` checks to auto-close dialogs and overlays when the app is backgrounded.
- **Settings & Persistence:**
    - Fixed race conditions when resetting preferences.
    - Persisted the active profile selection across app restarts.
- **UX Improvements:**
    - Refined Toast notification logic to prevent stacking.
    - Polished UI components (KDF slider visibility, animations, and badges).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full encryption profile system: create/save/edit/overwrite/select/delete with persistent profile library UI, profile save/overwrite dialogs, profile-driven encryption modes, key viewing, and a new Partitions screen.

* **Improvements**
  * New layered and raw encryption APIs, enhanced KDF handling, lifecycle-aware locking with smoother lock/unlock transitions, biometric retry/PIN fallback, single-toast feedback, secure clipboard handling, data wipe and reset flows.

* **Chores**
  * App version bumped to 0.5.0-dev02 and build updates including Compose foundation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->